### PR TITLE
Add "Edit on GitHub" link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -57,7 +57,12 @@ module.exports = {
         algolia: {
             apiKey: '1194997ecec7d141de5c746bc3463e9c',
             indexName: 'chainstack'
-        }
+        },
+        docsRepo: 'chainstack/docs',
+        docsDir: 'docs',
+        editLinks: true,
+        editLinkText: 'Edit on GitHub'
+   
     },
     plugins: {
         '@vuepress/google-analytics': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chainstack-docs",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Add the "Edit on GitHub" links to every docs topic. The goal is to have
a fast feedback lane for the docs and community engagement.
Closes #43