### PR TITLE
Add multichain hybrid guide

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,9 +14,9 @@ module.exports = {
                 collapsable: false,
                 children: [
                     '/guides/getting-started',
-                    '/guides/multichain-hybrid',
                     '/guides/interacting-with-the-blockchain',
                     '/guides/application-development',
+                    '/guides/multichain-hybrid',
                     '/guides/on-chain-governance',
                 ]
             },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,6 +14,7 @@ module.exports = {
                 collapsable: false,
                 children: [
                     '/guides/getting-started',
+                    '/guides/multichain-hybrid',
                     '/guides/interacting-with-the-blockchain',
                     '/guides/application-development',
                     '/guides/on-chain-governance',

--- a/docs/guides/multichain-hybrid.md
+++ b/docs/guides/multichain-hybrid.md
@@ -81,14 +81,14 @@ multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
-* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
-* PORT — your MultiChain cloud deployment port. Available under **Credentials** —> **Port**.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
+* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX`.
+* PORT — your MultiChain cloud deployment port. Always use the default value `7447`.
 
 Command example:
 
 ```
-multichaind nw-784-155-2@nd-339-567-264.rg-441-738.p2pify.com:7447 -daemon
+multichaind nw-784-155-2@nd-339-567-264.int.chainstack.com:7447 -daemon
 ```
 
 As a result of running the command, you will have:
@@ -103,17 +103,17 @@ MultiChain 2.0.2 Daemon (Community Edition, latest protocol 20010)
 
 Starting up node...
 
-Retrieving blockchain parameters from the seed node nd-339-567-264.rg-441-738.p2pify.com:7447 ...
+Retrieving blockchain parameters from the seed node nd-123-456-789.int.chainstack.com:7447 ...
 Blockchain successfully initialized.
 
 Please ask blockchain admin or user having activate permission to let you connect and/or transact:
-multichain-cli nw-784-155-2 grant 14SW7CidNbktZxkTSzi52iLvXviHyPebqCaW1q connect
-multichain-cli nw-784-155-2 grant 14SW7CidNbktZxkTSzi52iLvXviHyPebqCaW1q connect,send,receive
+multichain-cli nw-784-155-2 grant 14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q connect
+multichain-cli nw-784-155-2 grant 14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q connect,send,receive
 ```
 
 ### 6. Grant permissions to your on-premises MultiChain node
 
-You can use tools like [curl](https://curl.haxx.se/) or [Postman](https://www.getpostman.com/) to invoke [MultiChain API methods](https://www.multichain.com/developers/json-rpc-api/).
+For information on how to connect to and interact with a MultiChain node, see [Interacting with the blockchain](/guides/interacting-with-the-blockchain#multichain).
 
 On your on-premises machine, grant your on-premises MultiChain node's wallet address with the `grant` method and the following permissions:
 
@@ -124,21 +124,21 @@ On your on-premises machine, grant your on-premises MultiChain node's wallet add
 Sending a curl request from terminal:
 
 ```
-curl HOSTNAME -u "USERNAME:PASSWORD" -d {"method":"grant","params":["WALLET_ADDRESS","connect,send,receive"],"chain_name":"CHAIN_NAME"}'
+curl RPC_ENDPOINT -u "RPC_USER:RPC_PASSWORD" -d {"method":"grant","params":["WALLET_ADDRESS","connect,send,receive"],"chain_name":"CHAIN_NAME"}'
 ```
 
 where
 
-* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
-* USERNAME — your MultiChain cloud deployment username. Available under **Credentials** —> **User**.
-* PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** —> **Password**.
+* RPC_ENDPOINT — your MultiChain cloud deployment RPC endpoint. Available under **Credentials** > **RPC endpoint**.
+* RPC_USER — your MultiChain cloud deployment username. Available under **Credentials** > **RPC user**.
+* RPC_PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** > **RPC password**.
 * WALLET_ADDRESS — your MultiChain on-premises node's wallet address. You received the wallet address at the end of [Step 5](multichain-hybrid#_5-initialize-your-on-premises-multichain-node).
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
 
 Command example:
 
 ```
-curl https://nd-339-567-264.p2pify.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"grant","params":["14SW7CidNbktZxkTSzi52iLvXviHyPebqCaW1q","connect,send,receive"],"chain_name":"nw-784-155-2"}'
+curl https://nd-123-456-789.int.chainstack.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"grant","params":["14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q","connect,send,receive"],"chain_name":"nw-123-456-7"}'
 ```
 
 Output example:
@@ -154,22 +154,22 @@ On your on-premises machine, add your on-premises MultiChain node to the network
 Sending a curl request from terminal:
 
 ```console
-curl HOSTNAME -u "USERNAME:PASSWORD" -d '{"method":"addnode","params":["ON_PREM_IP:PORT","add"],"chain_name":"CHAIN_NAME"}'
+curl RPC_ENDPOINT -u "RPC_USER:RPC_PASSWORD" -d '{"method":"addnode","params":["ON_PREM_IP:PORT","add"],"chain_name":"CHAIN_NAME"}'
 ```
 
 where
 
-* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
-* USERNAME — your MultiChain cloud deployment username. Available under **Credentials** —> **User**.
-* PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** —> **Password**.
+* RPC_ENDPOINT — your MultiChain cloud deployment RPC endpoint. Available under **Credentials** > **RPC endpoint**.
+* RPC_USER — your MultiChain cloud deployment username. Available under **Credentials** > **RPC user**.
+* RPC_PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** > **RPC password**.
 * ON_PREM_IP — your MultiChain on-premises machine's IP address.
 * PORT — your MultiChain on-premises machine's port.
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
 
 Command example:
 
 ```console
-curl https://nd-339-567-264.p2pify.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"addnode","params":["178.62.100.80:7447","add"],"chain_name":"nw-784-155-2"}'
+curl https://nd-123-456-789.int.chainstack.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"addnode","params":["123.45.100.80:7447","add"],"chain_name":"nw-123-456-7"}'
 ```
 
 ### 8. Connect to the MultiChain network
@@ -184,14 +184,14 @@ multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
-* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
-* PORT — your MultiChain cloud deployment port. Available under **Credentials** —> **Port**.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
+* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX`.
+* PORT — your MultiChain cloud deployment port. Always use the default value `7447`.
 
 Command example:
 
 ```console
-multichaind nw-784-155-2@nd-339-567-264.rg-441-738.p2pify.com:7447 -daemon
+multichaind nw-123-456-7@nd-123-456-789.int.chainstack.com:7447 -daemon
 ```
 
 ## Interact from any node
@@ -210,14 +210,14 @@ multichain-cli CHAIN_NAME@IP_ADDRESS:PORT
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
 * IP_ADDRESS — your on-premises machine name's IP address.
 * PORT — your on-premises node's peer port.
 
 Example command:
 
 ```
-multichain-cli nw-784-155-2@178.62.100.80:7447
+multichain-cli nw-123-456-7@123.45.100.80:7447
 ```
 
 ### Enter multichain-cli interactive mode through your cloud node
@@ -230,14 +230,14 @@ multichain-cli CHAIN_NAME@HOSTNAME:PORT
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
 * HOSTNAME — your on-premises machine's IP address.
 * PORT — your on-premises node's peer port.
 
 Example command:
 
 ```console
-multichain-cli nw-784-155-2@nd-339-567-264.rg-441-738.p2pify.com:7447
+multichain-cli nw-123-456-7@nd-123-456-789.int.chainstack.com:7447
 ```
 
 ### Run commands in interactive mode
@@ -249,13 +249,108 @@ Examples:
 Get the node and blockchain information:
 
 ```console
-getinfo
+nw-123-456-7: getinfo
+```
+
+Example output:
+
+```
+{"method":"getinfo","params":[],"id":"64739383-1561354299","chain_name":"nw-123-456-7"}
+
+{
+    "version" : "2.0.2",
+    "nodeversion" : 20002901,
+    "protocolversion" : 20004,
+    "chainname" : "nw-123-456-7",
+    "description" : "My Network",
+    "protocol" : "multichain",
+    "port" : 7447,
+    "setupblocks" : 60,
+    "nodeaddress" : "nw-123-456-7@123.45.100.80:7447",
+    "burnaddress" : "1XXXXXXX24XXXXXXoiXXXXXXegXXXXXXURq4HJ",
+    "incomingpaused" : false,
+    "miningpaused" : false,
+    "offchainpaused" : false,
+    "walletversion" : 60000,
+    "balance" : 0,
+    "walletdbversion" : 3,
+    "reindex" : false,
+    "blocks" : 70,
+    "timeoffset" : 0,
+    "connections" : 2,
+    "proxy" : "",
+    "difficulty" : 5.96046447753906e-8,
+    "testnet" : false,
+    "keypoololdest" : 1560923993,
+    "keypoolsize" : 2,
+    "paytxfee" : 0,
+    "relayfee" : 0,
+    "errors" : ""
+}
 ```
 
 Get information about the other nodes to which this node is connected
 
 ```console
-getpeerinfo
+nw-123-456-7: getpeerinfo
+```
+
+Example output:
+
+```
+{"method":"getpeerinfo","params":[],"id":"18369030-1561354022","chain_name":"nw-123-456-7"}
+
+[
+    {
+        "id" : 1,
+        "addr" : "35.240.131.147:55052",
+        "addrlocal" : "123.45.100.80:7447",
+        "services" : "0000000000000001",
+        "lastsend" : 1561354022,
+        "lastrecv" : 1561354012,
+        "bytessent" : 1793,
+        "bytesrecv" : 1761,
+        "conntime" : 1561354001,
+        "pingtime" : 0.498706,
+        "pingwait" : 0.123433,
+        "version" : 70002,
+        "subver" : "/MultiChain:0.2.0.9/",
+        "handshakelocal" : "14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q",
+        "handshake" : "13849V95zfosL2RKKFCXcMrTBZdGU8XBiWNxum",
+        "inbound" : true,
+        "startingheight" : 70,
+        "banscore" : 0,
+        "synced_headers" : 70,
+        "synced_blocks" : 70,
+        "inflight" : [
+        ],
+        "whitelisted" : false
+    },
+    {
+        "id" : 2,
+        "addr" : "34.87.116.95:7447",
+        "addrlocal" : "10.148.0.55:49608",
+        "services" : "0000000000000001",
+        "lastsend" : 1561354013,
+        "lastrecv" : 1561354013,
+        "bytessent" : 937,
+        "bytesrecv" : 938,
+        "conntime" : 1561354012,
+        "pingtime" : 0.526633,
+        "version" : 70002,
+        "subver" : "/MultiChain:0.2.0.9/",
+        "handshakelocal" : "14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q",
+        "handshake" : "13849V95zfosL2RKKFCXcMrTBZdGU8XBiWNxum",
+        "inbound" : false,
+        "startingheight" : 70,
+        "banscore" : 0,
+        "synced_headers" : -1,
+        "synced_blocks" : -1,
+        "inflight" : [
+        ],
+        "whitelisted" : false
+    }
+]
 ```
 
 ::: tip See also:

--- a/docs/guides/multichain-hybrid.md
+++ b/docs/guides/multichain-hybrid.md
@@ -20,50 +20,49 @@ By the end of the section, you will have your MultiChain nodes from the same net
 To deploy a hybrid MultiChain network, do the following:
 
 1. With Chainstack, create a [Consortium](/projects/consortium) project.
-2. With Chainstack, deploy a MultiChain network in cloud.
-3. With Chainstack, get your cloud MultiChain node access information.
-4. On-premises, install MultiChain.
-5. On-premises, initialize your MultiChain node.
-6. From your cloud MultiChain node, grant permissions to your on-premises MultiChain node's wallet address.
-7. From your cloud MultiChain node, add your on-premises MultiChain node to the network.
-8. From your on-premises MultiChain node, connect to the MultiChain network.
+1. With Chainstack, deploy a MultiChain network in cloud.
+1. With Chainstack, get your cloud MultiChain node access information.
+1. On-premises, install MultiChain.
+1. On-premises, initialize your MultiChain node.
+1. From your cloud MultiChain node, grant permissions to your on-premises MultiChain node's wallet address.
+1. From your cloud MultiChain node, add your on-premises MultiChain node to the network.
+1. From your on-premises MultiChain node, connect to the MultiChain network.
 
 ## Step-by-step
 
 ### 1. Create a Consortium project
 
 1. Log in to your [Chainstack](https://console.chainstack.com/) account.
-2. Click **Create project**.
-3. Click **Consortium**.
-3. Provide **Project name** and optionally **Description**.
-4. Click **Create**.
+1. Click **Create project**.
+1. Click **Consortium**.
+1. Provide **Project name** and optionally **Description**.
+1. Click **Create**.
 
 This will create a project with Chainstack.
 
 ### 2. Deploy a MultiChain network
 
 1. Select the created project and click **Get started**.
-2. Provide **Network name**.
-3. Under **Blockchain protocol**, select **MultiChain**. Click **Next**.
-4. Under **Cloud hosting provider**, select your preferred provider.
-5. Under **Region**, select the region for your deployment.
+1. Provide **Network name**.
+1. Under **Blockchain protocol**, select **MultiChain**. Click **Next**.
+1. Under **Cloud hosting provider**, select your preferred provider.
+1. Under **Region**, select the region for your deployment.
+1. Review your changes and click **Create network**.
 
-  ::: warning
-  Currently only **Asia-Pacific** is available.
-  :::
-
-6. Review your changes and click **Create network**.
+::: warning
+Currently only **Asia-Pacific** region is available for deployment.
+:::
 
 The network status will change from **Pending** to **Running** once deployed.
 
 ### 3. Get your cloud MultiChain node access information
 
-::: tip Use your first node 
-You need to get the access information for your first MultiChain node as this node has the administrator address.
+::: warning
+You need to get the access information for the first MultiChain node in your the network as this node has the administrator address.
 :::
 
 1. In your MultiChain deployment project, click your MultiChain network name.
-2. Under **Node name**, click your first deployed node.
+1. Under **Node name**, click your first deployed node.
 
 Under **Credentials**, you will see your MultiChain node access information.
 
@@ -79,26 +78,22 @@ On your on-premises machine, attempt to connect to the cloud node to initialize 
 
 Run:
 
-```
-multichaind CHAIN_NAME@HOSTNAME-ORG_ID:PORT -daemon
+``` sh
+multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 ```
 
 where
 
 * CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME-ORG_ID — your cloud MultiChain node hostname and Organization ID.
-  * Get your hostname under **Credentials** as part of **RPC endpoint**.
-  * Get your Organization ID on your [Organization Settings](https://console.chainstack.com/user/settings/organization) page. <br />
-    The format is `nd-XXX-XXX-XXX.rg-XXX-XXX.p2pify.com`.    
+* HOSTNAME — your cloud MultiChain node hostname.
+  * Get your RPC hostname under **Credentials** as part of **RPC endpoint**.
+  * Get your Organization ID on your [Organization Settings](https://console.chainstack.com/user/settings/organization) page.
+  * Combine them using the following format: `nd-XXX-XXX-XXX.rg-XXX-XXX.p2pify.com`.
 * PORT — your cloud MultiChain node port. Always use the default value `7447`.
 
-Command example for:
+Command example:
 
-* CHAIN_NAME: `nw-123-456-7`
-* HOSTNAME: `nd-123-456-789`
-* ORG_ID: `rg-123-456`
-
-```
+``` sh
 multichaind nw-123-456-7@nd-123-456-789.rg-123-456.p2pify.com:7447 -daemon
 ```
 
@@ -132,7 +127,7 @@ On your on-premises machine, grant your on-premises MultiChain node's wallet add
 * `send`
 * `receive`
 
-::: tip Use your first node 
+::: warning
 You need to send the `grant` request through your first deployed node as specified in [Step 3](multichain-hybrid#_3-get-your-cloud-multichain-node-access-information).
 :::
 
@@ -200,13 +195,16 @@ multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 where
 
 * CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME — your cloud MultiChain node hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX.p2pify.com`.
+* HOSTNAME — your cloud MultiChain node hostname.
+  * Get your RPC hostname under **Credentials** as part of **RPC endpoint**.
+  * Get your Organization ID on your [Organization Settings](https://console.chainstack.com/user/settings/organization) page.
+  * Combine them using the following format: `nd-XXX-XXX-XXX.rg-XXX-XXX.p2pify.com`.
 * PORT — your cloud MultiChain node port. Always use the default value `7447`.
 
 Command example:
 
 ``` sh
-multichaind nw-123-456-7@nd-123-456-789.p2pify.com:7447 -daemon
+multichaind nw-123-456-7@nd-123-456-789.rg-123-456.p2pify.com:7447 -daemon
 ```
 
 ## Interact from any node
@@ -220,31 +218,28 @@ You can interact through your on-premises node or your cloud node.
 Enter interactive mode:
 
 ``` sh
-multichain-cli CHAIN_NAME@IP_ADDRESS:PORT
+multichain-cli CHAIN_NAME
 ```
 
 where
 
 * CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
-* IP_ADDRESS — your on-premises MultiChain node machine's IP address.
-* PORT — your on-premises MultiChain node machine's port.
 
-Example commands:
+Command example:
 
-* Connect:
-    ``` sh
-    multichain-cli nw-123-456-7@123.45.100.80:7447
-    ```
+``` sh
+multichain-cli nw-123-456-7
+```
 
-* Send `getinfo`:
+After entering interactive mode, send any command. For example, `getinfo` to get the node and blockchain information:
 
-    ``` sh
-    nw-123-456-7: getinfo
-    ```
+```
+nw-123-456-7: getinfo
+```
 
 Example output:
 
-```
+``` json
 {"method":"getinfo","params":[],"id":"64739383-1561354299","chain_name":"nw-123-456-7"}
 
 {
@@ -286,19 +281,19 @@ Run any [MultiChain JSON-RPC command](https://www.multichain.com/developers/json
 Send `getinfo` to get the node and blockchain information:
 
 ``` sh
-curl https://nd-123-456-789.p2pify.com -u "modest-cori:ought-vilify-parcel-urging-dime-sixth"-d '{"method":"getinfo","params":[],"id":1,"chain_name":"nw-123-456-7"}'
+curl https://nd-123-456-789.p2pify.com -u "modest-cori:ought-vilify-parcel-urging-dime-sixth"-d '{"method":"getinfo","params":[],"id":3,"chain_name":"nw-123-456-7"}'
 ```
 
 Example output:
 
-```
-{"result":{"version":"2.0","nodeversion":20000901,"protocolversion":20004,"chainname":"nw-123-456-7","description":"My Network","protocol":"multichain","port":7447,"setupblocks":60,"nodeaddress":"nw-123-456-7@12.34.56.78:7447","burnaddress":"1XXXXXXX24XXXXXXoiXXXXXXegXXXXXXURq4HJ","incomingpaused":false,"miningpaused":false,"offchainpaused":false,"walletversion":60000,"balance":0,"walletdbversion":3,"reindex":false,"blocks":81,"timeoffset":0,"connections":3,"proxy":"","difficulty":5.96046447753906e-8,"testnet":false,"keypoololdest":1561618750,"keypoolsize":2,"paytxfee":0,"relayfee":0,"errors":""},"error":null,"id":1}
-"}'
+``` json
+{"result":{"version":"2.0","nodeversion":20000901,"protocolversion":20004,"chainname":"nw-123-456-7","description":"My Network","protocol":"multichain","port":7447,"setupblocks":60,"nodeaddress":"nw-123-456-7@12.34.56.78:7447","burnaddress":"1XXXXXXX24XXXXXXoiXXXXXXegXXXXXXURq4HJ","incomingpaused":false,"miningpaused":false,"offchainpaused":false,"walletversion":60000,"balance":0,"walletdbversion":3,"reindex":false,"blocks":81,"timeoffset":0,"connections":3,"proxy":"","difficulty":5.96046447753906e-8,"testnet":false,"keypoololdest":1561618750,"keypoolsize":2,"paytxfee":0,"relayfee":0,"errors":""},"error":null,"id":3}
 ```
 
 Send any [MultiChain JSON-RPC command](https://www.multichain.com/developers/json-rpc-api/).
 
 ::: tip See also:
+
 * [Interacting with the blockchain](/guides/interacting-with-the-blockchain#multichain)
 * [Application development](/guides/application-development)
 * [MultiChain permissions management](https://www.multichain.com/developers/permissions-management/)

--- a/docs/guides/multichain-hybrid.md
+++ b/docs/guides/multichain-hybrid.md
@@ -76,19 +76,26 @@ On your on-premises machine, attempt to connect to the cloud node to initialize 
 Run:
 
 ```
-multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
+multichaind CHAIN_NAME@HOSTNAME-ORG_ID:PORT -daemon
 ```
 
 where
 
 * CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME — your cloud MultiChain node hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX.p2pify.com`.
+* HOSTNAME-ORG_ID — your cloud MultiChain node hostname and Organization ID.
+  * Get your hostname under **Credentials** as part of **RPC endpoint**.
+  * Get your Organization ID on your [Organization Settings](https://console.chainstack.com/user/settings/organization) page. <br />
+    The format is `nd-XXX-XXX-XXX.rg-XXX-XXX.p2pify.com`.    
 * PORT — your cloud MultiChain node port. Always use the default value `7447`.
 
-Command example:
+Command example for:
+
+* CHAIN_NAME: `nw-123-456-7`
+* HOSTNAME: `nd-123-456-789`
+* ORG_ID: `rg-123-456`
 
 ```
-multichaind nw-123-456-7@nd-123-456-789.p2pify.com:7447 -daemon
+multichaind nw-123-456-7@nd-123-456-789.rg-123-456.p2pify.com:7447 -daemon
 ```
 
 As a result of running the command, you will have:
@@ -196,7 +203,7 @@ multichaind nw-123-456-7@nd-123-456-789.p2pify.com:7447 -daemon
 
 ## Interact from any node
 
-Now that the MultiChain network is running in a hybrid environment, you can interact with it through `multichain-cli`.
+Now that the MultiChain network is running in a hybrid environment, you can interact with it.
 
 You can interact through your on-premises node or your cloud node.
 
@@ -214,43 +221,18 @@ where
 * IP_ADDRESS — your on-premises MultiChain node machine's IP address.
 * PORT — your on-premises MultiChain node machine's port.
 
-Example command:
+Example commands:
 
-``` sh
-multichain-cli nw-123-456-7@123.45.100.80:7447
-```
+* Connect:
+    ``` sh
+    multichain-cli nw-123-456-7@123.45.100.80:7447
+    ```
 
-### Enter multichain-cli interactive mode through your cloud node
+* Send `getinfo`:
 
-Enter interactive mode:
-
-``` sh
-multichain-cli CHAIN_NAME@HOSTNAME:PORT
-```
-
-where
-
-* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME — your cloud MultiChain node hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX.p2pify.com`.
-* PORT — your cloud MultiChain node port. Always use the default value `7447`.
-
-Example command:
-
-``` sh
-multichain-cli nw-123-456-7@nd-123-456-789.p2pify.com:7447
-```
-
-### Run commands in interactive mode
-
-Once in interactive mode, run any [MultiChain JSON-RPC command](https://www.multichain.com/developers/json-rpc-api/).
-
-Examples:
-
-Get the node and blockchain information:
-
-``` sh
-nw-123-456-7: getinfo
-```
+    ``` sh
+    nw-123-456-7: getinfo
+    ```
 
 Example output:
 
@@ -289,69 +271,24 @@ Example output:
 }
 ```
 
-Get information about the other nodes to which this node is connected
+Run any [MultiChain JSON-RPC command](https://www.multichain.com/developers/json-rpc-api/).
+
+### Send commands to your cloud node
+
+Send `getinfo` to get the node and blockchain information:
 
 ``` sh
-nw-123-456-7: getpeerinfo
+curl https://nd-123-456-789.p2pify.com -u "modest-cori:ought-vilify-parcel-urging-dime-sixth"-d '{"method":"getinfo","params":[],"id":1,"chain_name":"nw-123-456-7"}'
 ```
 
 Example output:
 
 ```
-{"method":"getpeerinfo","params":[],"id":"18369030-1561354022","chain_name":"nw-123-456-7"}
-
-[
-    {
-        "id" : 1,
-        "addr" : "35.240.131.147:55052",
-        "addrlocal" : "123.45.100.80:7447",
-        "services" : "0000000000000001",
-        "lastsend" : 1561354022,
-        "lastrecv" : 1561354012,
-        "bytessent" : 1793,
-        "bytesrecv" : 1761,
-        "conntime" : 1561354001,
-        "pingtime" : 0.498706,
-        "pingwait" : 0.123433,
-        "version" : 70002,
-        "subver" : "/MultiChain:0.2.0.9/",
-        "handshakelocal" : "14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q",
-        "handshake" : "13849V95zfosL2RKKFCXcMrTBZdGU8XBiWNxum",
-        "inbound" : true,
-        "startingheight" : 70,
-        "banscore" : 0,
-        "synced_headers" : 70,
-        "synced_blocks" : 70,
-        "inflight" : [
-        ],
-        "whitelisted" : false
-    },
-    {
-        "id" : 2,
-        "addr" : "34.87.116.95:7447",
-        "addrlocal" : "10.148.0.55:49608",
-        "services" : "0000000000000001",
-        "lastsend" : 1561354013,
-        "lastrecv" : 1561354013,
-        "bytessent" : 937,
-        "bytesrecv" : 938,
-        "conntime" : 1561354012,
-        "pingtime" : 0.526633,
-        "version" : 70002,
-        "subver" : "/MultiChain:0.2.0.9/",
-        "handshakelocal" : "14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q",
-        "handshake" : "13849V95zfosL2RKKFCXcMrTBZdGU8XBiWNxum",
-        "inbound" : false,
-        "startingheight" : 70,
-        "banscore" : 0,
-        "synced_headers" : -1,
-        "synced_blocks" : -1,
-        "inflight" : [
-        ],
-        "whitelisted" : false
-    }
-]
+{"result":{"version":"2.0","nodeversion":20000901,"protocolversion":20004,"chainname":"nw-123-456-7","description":"My Network","protocol":"multichain","port":7447,"setupblocks":60,"nodeaddress":"nw-123-456-7@12.34.56.78:7447","burnaddress":"1XXXXXXX24XXXXXXoiXXXXXXegXXXXXXURq4HJ","incomingpaused":false,"miningpaused":false,"offchainpaused":false,"walletversion":60000,"balance":0,"walletdbversion":3,"reindex":false,"blocks":81,"timeoffset":0,"connections":3,"proxy":"","difficulty":5.96046447753906e-8,"testnet":false,"keypoololdest":1561618750,"keypoolsize":2,"paytxfee":0,"relayfee":0,"errors":""},"error":null,"id":1}
+"}'
 ```
+
+Send any [MultiChain JSON-RPC command](https://www.multichain.com/developers/json-rpc-api/).
 
 ::: tip See also:
 * [Interacting with the blockchain](/guides/interacting-with-the-blockchain#multichain)

--- a/docs/guides/multichain-hybrid.md
+++ b/docs/guides/multichain-hybrid.md
@@ -58,8 +58,12 @@ The network status will change from **Pending** to **Running** once deployed.
 
 ### 3. Get your cloud MultiChain node access information
 
+::: tip Use your first node 
+You need to get the access information for your first MultiChain node as this node has the administrator address.
+:::
+
 1. In your MultiChain deployment project, click your MultiChain network name.
-2. Under **Node name**, click your node.
+2. Under **Node name**, click your first deployed node.
 
 Under **Credentials**, you will see your MultiChain node access information.
 
@@ -127,6 +131,10 @@ On your on-premises machine, grant your on-premises MultiChain node's wallet add
 * `conect`
 * `send`
 * `receive`
+
+::: tip Use your first node 
+You need to send the `grant` request through your first deployed node as specified in [Step 3](multichain-hybrid#_3-get-your-cloud-multichain-node-access-information).
+:::
 
 Sending a curl request from terminal:
 
@@ -293,4 +301,5 @@ Send any [MultiChain JSON-RPC command](https://www.multichain.com/developers/jso
 ::: tip See also:
 * [Interacting with the blockchain](/guides/interacting-with-the-blockchain#multichain)
 * [Application development](/guides/application-development)
+* [MultiChain permissions management](https://www.multichain.com/developers/permissions-management/)
 :::

--- a/docs/guides/multichain-hybrid.md
+++ b/docs/guides/multichain-hybrid.md
@@ -6,7 +6,7 @@ By the end of the section, you will have your MultiChain nodes from the same net
 
 ## Prerequisites
 
-* [Chainstack account](https://console.chainstack.com/)
+* [Chainstack](https://console.chainstack.com/) account
 * A supported operating system for the MultiChain on-premises deployment:
   * Linux 64-bit: Ubuntu 12.04+, CentOS 6.2+, Debian 7+, Fedora 15+, RHEL 6.2+
   * Windows 64-bit: Windows 7, 8, 10, Server 2008 or later
@@ -32,7 +32,7 @@ To deploy a hybrid MultiChain network, do the following:
 
 ### 1. Create a Consortium project
 
-1. Log in to your [Chainstack account](https://console.chainstack.com/).
+1. Log in to your [Chainstack](https://console.chainstack.com/) account.
 2. Click **Create project**.
 3. Click **Consortium**.
 3. Provide **Project name** and optionally **Description**.
@@ -81,14 +81,14 @@ multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX`.
-* PORT — your MultiChain cloud deployment port. Always use the default value `7447`.
+* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
+* HOSTNAME — your cloud MultiChain node hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX.p2pify.com`.
+* PORT — your cloud MultiChain node port. Always use the default value `7447`.
 
 Command example:
 
 ```
-multichaind nw-784-155-2@nd-339-567-264.int.chainstack.com:7447 -daemon
+multichaind nw-123-456-7@nd-123-456-789.p2pify.com:7447 -daemon
 ```
 
 As a result of running the command, you will have:
@@ -103,12 +103,12 @@ MultiChain 2.0.2 Daemon (Community Edition, latest protocol 20010)
 
 Starting up node...
 
-Retrieving blockchain parameters from the seed node nd-123-456-789.int.chainstack.com:7447 ...
+Retrieving blockchain parameters from the seed node nd-123-456-789.p2pify.com:7447 ...
 Blockchain successfully initialized.
 
 Please ask blockchain admin or user having activate permission to let you connect and/or transact:
-multichain-cli nw-784-155-2 grant 14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q connect
-multichain-cli nw-784-155-2 grant 14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q connect,send,receive
+multichain-cli nw-123-456-7 grant 14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q connect
+multichain-cli nw-123-456-7 grant 14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q connect,send,receive
 ```
 
 ### 6. Grant permissions to your on-premises MultiChain node
@@ -123,28 +123,28 @@ On your on-premises machine, grant your on-premises MultiChain node's wallet add
 
 Sending a curl request from terminal:
 
-```
-curl RPC_ENDPOINT -u "RPC_USER:RPC_PASSWORD" -d {"method":"grant","params":["WALLET_ADDRESS","connect,send,receive"],"chain_name":"CHAIN_NAME"}'
+``` sh
+curl RPC_ENDPOINT -u "RPC_USER:RPC_PASSWORD" -d {"method":"grant","params":["WALLET_ADDRESS","connect,send,receive"],"id":1,"chain_name":"CHAIN_NAME"}'
 ```
 
 where
 
-* RPC_ENDPOINT — your MultiChain cloud deployment RPC endpoint. Available under **Credentials** > **RPC endpoint**.
-* RPC_USER — your MultiChain cloud deployment username. Available under **Credentials** > **RPC user**.
-* RPC_PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** > **RPC password**.
-* WALLET_ADDRESS — your MultiChain on-premises node's wallet address. You received the wallet address at the end of [Step 5](multichain-hybrid#_5-initialize-your-on-premises-multichain-node).
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
+* RPC_ENDPOINT — your cloud MultiChain node RPC endpoint. Available under **Credentials** > **RPC endpoint**.
+* RPC_USER — your cloud MultiChain node RPC username. Available under **Credentials** > **RPC user**.
+* RPC_PASSWORD — your cloud MultiChain node RPC password. Available under **Credentials** > **RPC password**.
+* WALLET_ADDRESS — your on-premises MultiChain node's wallet address. You received the wallet address at the end of [Step 5](multichain-hybrid#_5-initialize-your-on-premises-multichain-node).
+* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
 
 Command example:
 
-```
-curl https://nd-123-456-789.int.chainstack.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"grant","params":["14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q","connect,send,receive"],"chain_name":"nw-123-456-7"}'
+``` sh
+curl https://nd-123-456-789.p2pify.com -u "modest-cori:ought-vilify-parcel-urging-dime-sixth" -d '{"method":"grant","params":["14SW7RsdNbktZxkTSzi52iLvXviHyPebqCaW1q","connect,send,receive"],"id":1,"chain_name":"nw-123-456-7"}'
 ```
 
 Output example:
 
-```
-{"result":"17859d3efdaa95bc9d1573e539a9b5177e17debb6afe37078ac6c4bd1bec9821","error":null,"id":null}
+``` json
+{"result":"17859d3efdaa95bc9d1573e539a9b5177e17debb6afe37078ac6c4bd1bec9821","error":null,"id":1}
 ```
 
 ### 7. Add your on-premises MultiChain node to the network
@@ -153,23 +153,23 @@ On your on-premises machine, add your on-premises MultiChain node to the network
 
 Sending a curl request from terminal:
 
-```console
-curl RPC_ENDPOINT -u "RPC_USER:RPC_PASSWORD" -d '{"method":"addnode","params":["ON_PREM_IP:PORT","add"],"chain_name":"CHAIN_NAME"}'
+``` sh
+curl RPC_ENDPOINT -u "RPC_USER:RPC_PASSWORD" -d '{"method":"addnode","params":["ON_PREM_IP:PORT","add"],"id":2,"chain_name":"CHAIN_NAME"}'
 ```
 
 where
 
-* RPC_ENDPOINT — your MultiChain cloud deployment RPC endpoint. Available under **Credentials** > **RPC endpoint**.
-* RPC_USER — your MultiChain cloud deployment username. Available under **Credentials** > **RPC user**.
-* RPC_PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** > **RPC password**.
-* ON_PREM_IP — your MultiChain on-premises machine's IP address.
-* PORT — your MultiChain on-premises machine's port.
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
+* RPC_ENDPOINT — your cloud MultiChain node RPC endpoint. Available under **Credentials** > **RPC endpoint**.
+* RPC_USER — your cloud MultiChain node RPC username. Available under **Credentials** > **RPC user**.
+* RPC_PASSWORD — your cloud MultiChain node RPC password. Available under **Credentials** > **RPC password**.
+* ON_PREM_IP — your on-premises MultiChain node machine's IP address.
+* PORT — your on-premises MultiChain node machine's port.
+* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
 
 Command example:
 
-```console
-curl https://nd-123-456-789.int.chainstack.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"addnode","params":["123.45.100.80:7447","add"],"chain_name":"nw-123-456-7"}'
+``` sh
+curl https://nd-123-456-789.p2pify.com -u "modest-cori:ought-vilify-parcel-urging-dime-sixth" -d '{"method":"addnode","params":["123.45.100.80:7447","add"],"id":2,"chain_name":"nw-123-456-7"}'
 ```
 
 ### 8. Connect to the MultiChain network
@@ -178,25 +178,25 @@ On your on-premises machine, connect to the MultiChain network.
 
 Run:
 
-```
+``` sh
 multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 ```
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX`.
-* PORT — your MultiChain cloud deployment port. Always use the default value `7447`.
+* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
+* HOSTNAME — your cloud MultiChain node hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX.p2pify.com`.
+* PORT — your cloud MultiChain node port. Always use the default value `7447`.
 
 Command example:
 
-```console
-multichaind nw-123-456-7@nd-123-456-789.int.chainstack.com:7447 -daemon
+``` sh
+multichaind nw-123-456-7@nd-123-456-789.p2pify.com:7447 -daemon
 ```
 
 ## Interact from any node
 
-Now that the MultiChain network is running in a hybrid deployment, you can interact with it through `multichain-cli`.
+Now that the MultiChain network is running in a hybrid environment, you can interact with it through `multichain-cli`.
 
 You can interact through your on-premises node or your cloud node.
 
@@ -204,19 +204,19 @@ You can interact through your on-premises node or your cloud node.
 
 Enter interactive mode:
 
-```console
+``` sh
 multichain-cli CHAIN_NAME@IP_ADDRESS:PORT
 ```
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
-* IP_ADDRESS — your on-premises machine name's IP address.
-* PORT — your on-premises node's peer port.
+* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
+* IP_ADDRESS — your on-premises MultiChain node machine's IP address.
+* PORT — your on-premises MultiChain node machine's port.
 
 Example command:
 
-```
+``` sh
 multichain-cli nw-123-456-7@123.45.100.80:7447
 ```
 
@@ -224,20 +224,20 @@ multichain-cli nw-123-456-7@123.45.100.80:7447
 
 Enter interactive mode:
 
-```console
+``` sh
 multichain-cli CHAIN_NAME@HOSTNAME:PORT
 ```
 
 where
 
-* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** > **Chain name**.
-* HOSTNAME — your on-premises machine's IP address.
-* PORT — your on-premises node's peer port.
+* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Credentials** > **Chain name**.
+* HOSTNAME — your cloud MultiChain node hostname. Available under **Credentials** as part of **RPC endpoint**. The format is `nd-XXX-XXX-XXX.p2pify.com`.
+* PORT — your cloud MultiChain node port. Always use the default value `7447`.
 
 Example command:
 
-```console
-multichain-cli nw-123-456-7@nd-123-456-789.int.chainstack.com:7447
+``` sh
+multichain-cli nw-123-456-7@nd-123-456-789.p2pify.com:7447
 ```
 
 ### Run commands in interactive mode
@@ -248,7 +248,7 @@ Examples:
 
 Get the node and blockchain information:
 
-```console
+``` sh
 nw-123-456-7: getinfo
 ```
 
@@ -291,7 +291,7 @@ Example output:
 
 Get information about the other nodes to which this node is connected
 
-```console
+``` sh
 nw-123-456-7: getpeerinfo
 ```
 

--- a/docs/guides/multichain-hybrid.md
+++ b/docs/guides/multichain-hybrid.md
@@ -1,0 +1,264 @@
+# Deploying a hybrid MultiChain network
+
+This section will guide you through the [hybrid deployment](/reference/glossary#hybrid) of a MultiChain network.
+
+By the end of the section, you will have your MultiChain nodes from the same network running in cloud and [on-premises](/reference/glossary#on-prem).
+
+## Prerequisites
+
+* [Chainstack account](https://console.chainstack.com/)
+* A supported operating system for the MultiChain on-premises deployment:
+  * Linux 64-bit: Ubuntu 12.04+, CentOS 6.2+, Debian 7+, Fedora 15+, RHEL 6.2+
+  * Windows 64-bit: Windows 7, 8, 10, Server 2008 or later
+  * Mac 64-bit: supports OS X 10.11 or later
+* System requirements for the MultiChain on-premises deployment:
+  * 512MB of RAM
+  * 1GB of disk space
+
+## Overview
+
+To deploy a hybrid MultiChain network, do the following:
+
+1. With Chainstack, create a [Consortium](/projects/consortium) project.
+2. With Chainstack, deploy a MultiChain network in cloud.
+3. With Chainstack, get your cloud MultiChain node access information.
+4. On-premises, install MultiChain.
+5. On-premises, initialize your MultiChain node.
+6. From your cloud MultiChain node, grant permissions to your on-premises MultiChain node's wallet address.
+7. From your cloud MultiChain node, add your on-premises MultiChain node to the network.
+8. From your on-premises MultiChain node, connect to the MultiChain network.
+
+## Step-by-step
+
+### 1. Create a Consortium project
+
+1. Log in to your [Chainstack account](https://console.chainstack.com/).
+2. Click **Create project**.
+3. Click **Consortium**.
+3. Provide **Project name** and optionally **Description**.
+4. Click **Create**.
+
+This will create a project with Chainstack.
+
+### 2. Deploy a MultiChain network
+
+1. Select the created project and click **Get started**.
+2. Provide **Network name**.
+3. Under **Blockchain protocol**, select **MultiChain**. Click **Next**.
+4. Under **Cloud hosting provider**, select your preferred provider.
+5. Under **Region**, select the region for your deployment.
+
+  ::: warning
+  Currently only **Asia-Pacific** is available.
+  :::
+
+6. Review your changes and click **Create network**.
+
+The network status will change from **Pending** to **Running** once deployed.
+
+### 3. Get your cloud MultiChain node access information
+
+1. In your MultiChain deployment project, click your MultiChain network name.
+2. Under **Node name**, click your node.
+
+Under **Credentials**, you will see your MultiChain node access information.
+
+### 4. Install MultiChain on-premises
+
+On your on-premises machine, install MultiChain.
+
+See [MultiChain 2.0: Download and Install MultiChain](https://www.multichain.com/download-install/).
+
+### 5. Initialize your on-premises MultiChain node
+
+On your on-premises machine, attempt to connect to the cloud node to initialize your on-premises node.
+
+Run:
+
+```
+multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
+```
+
+where
+
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
+* PORT — your MultiChain cloud deployment port. Available under **Credentials** —> **Port**.
+
+Command example:
+
+```
+multichaind nw-784-155-2@nd-339-567-264.rg-441-738.p2pify.com:7447 -daemon
+```
+
+As a result of running the command, you will have:
+
+* An initialized on-premises node.
+* Your on-premises node's wallet address.
+
+Output example:
+
+```
+MultiChain 2.0.2 Daemon (Community Edition, latest protocol 20010)
+
+Starting up node...
+
+Retrieving blockchain parameters from the seed node nd-339-567-264.rg-441-738.p2pify.com:7447 ...
+Blockchain successfully initialized.
+
+Please ask blockchain admin or user having activate permission to let you connect and/or transact:
+multichain-cli nw-784-155-2 grant 14SW7CidNbktZxkTSzi52iLvXviHyPebqCaW1q connect
+multichain-cli nw-784-155-2 grant 14SW7CidNbktZxkTSzi52iLvXviHyPebqCaW1q connect,send,receive
+```
+
+### 6. Grant permissions to your on-premises MultiChain node
+
+You can use tools like [curl](https://curl.haxx.se/) or [Postman](https://www.getpostman.com/) to invoke [MultiChain API methods](https://www.multichain.com/developers/json-rpc-api/).
+
+On your on-premises machine, grant your on-premises MultiChain node's wallet address with the `grant` method and the following permissions:
+
+* `conect`
+* `send`
+* `receive`
+
+Sending a curl request from terminal:
+
+```
+curl HOSTNAME -u "USERNAME:PASSWORD" -d {"method":"grant","params":["WALLET_ADDRESS","connect,send,receive"],"chain_name":"CHAIN_NAME"}'
+```
+
+where
+
+* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
+* USERNAME — your MultiChain cloud deployment username. Available under **Credentials** —> **User**.
+* PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** —> **Password**.
+* WALLET_ADDRESS — your MultiChain on-premises node's wallet address. You received the wallet address at the end of [Step 5](multichain-hybrid#_5-initialize-your-on-premises-multichain-node).
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+
+Command example:
+
+```
+curl https://nd-339-567-264.p2pify.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"grant","params":["14SW7CidNbktZxkTSzi52iLvXviHyPebqCaW1q","connect,send,receive"],"chain_name":"nw-784-155-2"}'
+```
+
+Output example:
+
+```
+{"result":"17859d3efdaa95bc9d1573e539a9b5177e17debb6afe37078ac6c4bd1bec9821","error":null,"id":null}
+```
+
+### 7. Add your on-premises MultiChain node to the network
+
+On your on-premises machine, add your on-premises MultiChain node to the network with the `addnode` method.
+
+Sending a curl request from terminal:
+
+```console
+curl HOSTNAME -u "USERNAME:PASSWORD" -d '{"method":"addnode","params":["ON_PREM_IP:PORT","add"],"chain_name":"CHAIN_NAME"}'
+```
+
+where
+
+* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
+* USERNAME — your MultiChain cloud deployment username. Available under **Credentials** —> **User**.
+* PASSWORD — your MultiChain cloud deployment password. Available under **Credentials** —> **Password**.
+* ON_PREM_IP — your MultiChain on-premises machine's IP address.
+* PORT — your MultiChain on-premises machine's port.
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+
+Command example:
+
+```console
+curl https://nd-339-567-264.p2pify.com -u "modest_cori:ought vilify parcel urging dime sixth" -d '{"method":"addnode","params":["178.62.100.80:7447","add"],"chain_name":"nw-784-155-2"}'
+```
+
+### 8. Connect to the MultiChain network
+
+On your on-premises machine, connect to the MultiChain network.
+
+Run:
+
+```
+multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
+```
+
+where
+
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* HOSTNAME — your MultiChain cloud deployment hostname. Available under **Credentials** —> **Host**.
+* PORT — your MultiChain cloud deployment port. Available under **Credentials** —> **Port**.
+
+Command example:
+
+```console
+multichaind nw-784-155-2@nd-339-567-264.rg-441-738.p2pify.com:7447 -daemon
+```
+
+## Interact from any node
+
+Now that the MultiChain network is running in a hybrid deployment, you can interact with it through `multichain-cli`.
+
+You can interact through your on-premises node or your cloud node.
+
+### Enter multichain-cli interactive mode through your on-premises node
+
+Enter interactive mode:
+
+```console
+multichain-cli CHAIN_NAME@IP_ADDRESS:PORT
+```
+
+where
+
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* IP_ADDRESS — your on-premises machine name's IP address.
+* PORT — your on-premises node's peer port.
+
+Example command:
+
+```
+multichain-cli nw-784-155-2@178.62.100.80:7447
+```
+
+### Enter multichain-cli interactive mode through your cloud node
+
+Enter interactive mode:
+
+```console
+multichain-cli CHAIN_NAME@HOSTNAME:PORT
+```
+
+where
+
+* CHAIN_NAME — your MultiChain cloud deployment chain name. Available under **Credentials** —> **Chain name**.
+* HOSTNAME — your on-premises machine's IP address.
+* PORT — your on-premises node's peer port.
+
+Example command:
+
+```console
+multichain-cli nw-784-155-2@nd-339-567-264.rg-441-738.p2pify.com:7447
+```
+
+### Run commands in interactive mode
+
+Once in interactive mode, run any [MultiChain JSON-RPC command](https://www.multichain.com/developers/json-rpc-api/).
+
+Examples:
+
+Get the node and blockchain information:
+
+```console
+getinfo
+```
+
+Get information about the other nodes to which this node is connected
+
+```console
+getpeerinfo
+```
+
+::: tip See also:
+* [Interacting with the blockchain](/guides/interacting-with-the-blockchain#multichain)
+* [Application development](/guides/application-development)
+:::

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -20,7 +20,7 @@ Deployment of a node on the company’s own infrastructure.
 
 ### Hybrid
 
-Depending on the blockchain protocol, a hybrid deployment could mean that some nodes of an organization are on-prem while others are on the public cloud.
+Depending on the blockchain protocol, a hybrid deployment could mean that some nodes of an organization are on-prem while others are on the public cloud. See also [Deploying a hybrid MultiChain network](/guides/multichain-hybrid).
 
 ## Member
 


### PR DESCRIPTION
Add the MultiChain hybrid deployment guide under "Guides".
Crosslink with glossary.
Closes #47