### PR TITLE
Fix Ropsten mentions

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -74,7 +74,9 @@ Create a public chain project by clicking **Create project** and choosing the **
 
 But this is just a beginning. To join a public chain network, Ethereum, in this case, click the project listing to view the **Join network** modal window. 
 
-Select **Ethereum** from **Blockchain protocol**. Network options available under the specific blockchain protocol are visible under **Blockchain network**. Select **Mainnet**.
+Select **Ethereum** from **Blockchain protocol**. Network options available under the specific blockchain protocol are visible under **Blockchain network**. Select **Mainnet** for the Ethereum main chain or **Ropsten Testnet** for the Ethereum test chain.
+
+See also [Public chain](/projects/public-chain).
 
 ![Join network](./getting-started/public-chain/join-network.png)
 

--- a/docs/projects/public-chain.md
+++ b/docs/projects/public-chain.md
@@ -6,7 +6,9 @@ Users can join a public blockchain network by deploying a new node or getting ac
 
 A public chain network comes in various flavors. There’s the mainnet, where the actual network lives and where users transact data and cryptocurrency. Not unlike a typical staging environment, there are also various testnets, which are ideal for smart contract development and testing.
 
-Chainstack currently supports joining Ethereum mainnet. Support for joining testnets such as Ropsten and Kovan will follow.
+Chainstack currently supports joining Ethereum mainnet and Ropsten testnet.
+
+To fund your address to interact with Ropsten, use [Ropsten Ethereum Faucet](https://faucet.ropsten.be/).
 
 ## Node types
 


### PR DESCRIPTION
Fix Ropsten support mentions.
Add Ropsten faucet link.
Note this is a quick fix for the current docs. Will be done differently
in the restructured version.
Closes #53