### PR TITLE
Fix texts for platform links

### DIFF
--- a/docs/blockchains/multichain.md
+++ b/docs/blockchains/multichain.md
@@ -4,7 +4,7 @@ MultiChain is a fork of Bitcoin Core.
 
 MultiChain is a permissioned consortium blockchain protocol.
 
-## Consensus algorithm
+## Consensus
 
 MultiChain achieves consensus by validating blocks in a round-robin scheme with a `mining-diversity` parameter.
 

--- a/docs/blockchains/quorum.md
+++ b/docs/blockchains/quorum.md
@@ -4,7 +4,7 @@ Quorum is a fork of Go Ethereum.
 
 Quorum is a permissioned consortium blockchain protocol.
 
-## Consensus algorithms
+## Consensus
 
 Quorum supports the following two consensus algorithms:
 

--- a/docs/glossary/consortium-project.md
+++ b/docs/glossary/consortium-project.md
@@ -2,6 +2,8 @@
 
 A [project](/glossary/project) to deploy [consortium](/glossary/consortium) blockchain networks.
 
+Chainstack supports [cloud](/glossary/cloud) and [hybrid](/glossary/hybrid) deployment of consortium blockchain networks.
+
 ::: tip See also
 
 * [Supported protocols](/platform/supported-protocols)

--- a/docs/glossary/public-chain-project.md
+++ b/docs/glossary/public-chain-project.md
@@ -2,10 +2,10 @@
 
 A [project](/glossary/project) to join a public networks.
 
+Chainstack supports the deployment of [dedicated](/glossary/dedicated-node) and [shared](/glossary/shared-node) nodes.
+
 ::: tip See also
 
 * [Supported protocols](/platform/supported-protocols)
-* [Dedicated node](/glossary/dedicated-node)
-* [Shared node](/glossary/shared-node)
 
 :::


### PR DESCRIPTION
Introduced minor modifications to texts and links
to have consistent links to the docs from the platform ui.
There's a separate commit in the ui repo (https://github.com/chainstack/ui/pull/1032) that links to the changes in docs introduced in this commit.