### PR TITLE
Fix ETH API protected exposure

### DIFF
--- a/docs/operations/ethereum/tools.md
+++ b/docs/operations/ethereum/tools.md
@@ -6,17 +6,39 @@ Interact with your Ethereum node using [Geth](https://github.com/ethereum/go-eth
 
 1. Install [Geth](https://github.com/ethereum/go-ethereum).
 
-2. Use `geth attach` command with the node RPC endpoint:
+2. Use `geth attach` command with the node's endpoint.
+
+RPC:
 
 ``` sh
-$ geth attach https://nd-123-456-789.p2pify.com:8545
+geth attach https://USERNAME:PASSWORD@RPC_ENDPOINT
+```
 
-Welcome to the Geth JavaScript console!
+WSS:
 
-instance: Geth/v1.8.22-stable-7fa3509e/linux-amd64/go1.11.5
- modules: eth:1.0 net:1.0 rpc:1.0 web3:1.0
+``` sh
+geth attach wss://USERNAME:PASSWORD@WSS_ENDPOINT
+```
 
->
+where
+
+* USERNAME — your Ethereum node access username.
+* PASSWORD — your Ethereum node access password.
+* RPC_ENDPOINT — your Ethereum node RPC endpoint.
+* WSS_ENDPOINT — your Ethereum node WSS endpoint.
+
+See [View node access and credentials](/platform/view-node-access-and-credentials).
+
+RPC example:
+
+``` sh
+geth attach https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com
+```
+
+WSS example:
+
+``` sh
+geth attach wss://user-name:pass-word-pass-word-pass-word@ws-nd-123-456-789.p2pify.com
 ```
 
 3. Invoke any methods from [Web3 JavaScript API](https://github.com/ethereum/wiki/wiki/JavaScript-API).
@@ -45,7 +67,7 @@ const mnemonic = 'pattern enroll upgrade ...';
 module.exports = {
  networks: {
     chainstack: {
-        provider: () => new HDWalletProvider(mnemonic, "https://nd-123-456-789.p2pify.com:8545"),
+        provider: () => new HDWalletProvider(mnemonic, "https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com"),
         network_id: 1
     },
    }
@@ -71,8 +93,8 @@ chainstack: {
         mnemonic: 'pattern enroll upgrade ...'
       }
     ],
-    host: "nd-123-456-789.p2pify.com",
-    port: 8545,
+    host: "user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com",
+    port: false,
     protocol: "https",
     type: "rpc"
   }
@@ -83,7 +105,7 @@ chainstack: {
 
 ::: tip See also
 
-* [Asset tokenization on Ethereum](/tutorials/academic-certificates-on-ethereum)
-* [Academic certificates on Ethereum](/tutorials/asset-tokenization-on-ethereum)
+* [Asset tokenization on Ethereum](/tutorials/asset-tokenization-on-ethereum)
+* [Academic certificates on Ethereum](/tutorials/academic-certificates-on-ethereum)
 
 :::

--- a/docs/tutorials/academic-certificates-on-ethereum.md
+++ b/docs/tutorials/academic-certificates-on-ethereum.md
@@ -157,7 +157,7 @@ module.exports = {
         network_id: "5777"
     },
     mainnet: {
-        provider: () => new HDWalletProvider(mnemonic, "https://nd-123-456-789.p2pify.com"),
+        provider: () => new HDWalletProvider(mnemonic, "https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com"),
         network_id: 1,
         gas: 4500000,
         gasPrice: 10000000000
@@ -268,7 +268,7 @@ To interact with the contracts deployed using Chainstack node, you need to creat
 
 ``` js
 const Web3 = require('web3')
-const web3 = new Web3('https://nd-123-456-789.p2pify.com')
+const web3 = new Web3('https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com')
 ```
 
 After creating your `web3` object, you can call different web3 methods to interact with the deployed contracts. Check [this tutorial](http://www.dappuniversity.com/articles/web3-js-intro) to know more and also read [web3 docs](https://web3js.readthedocs.io/en/1.0/web3-eth.html). 

--- a/docs/tutorials/asset-tokenization-on-ethereum.md
+++ b/docs/tutorials/asset-tokenization-on-ethereum.md
@@ -132,8 +132,32 @@ You will use this account to deploy the contract.
 
     * PATH_TO_KEYSTORE — the location of the keystore file.
     * PASSWORD — the password you provided when creating the Ethereum account with Geth.
-    * RPC_ENDPOINT — your Ropsten node RPC endpoint. Available under **Credentials** > **RPC endpoint**.  
+    * RPC_ENDPOINT — your Ropsten node RPC endpoint with username and password. The format is `user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com`. See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
+    Contract example:
+
+    ``` js
+    chainstack: {
+        deployment:{
+          accounts: [
+              {
+                privateKeyFile:"//root/.ethereum/keystore/UTC--2019-08-01T07-24-17.754471456Z--73236c8d8aaee5263e8a32c71171030dd7a3e8e6",
+                password:"123456"
+              }
+          ],
+          host: "user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com",
+          port:false,
+          protocol:"https",
+          type:"rpc"
+        },
+        dappConnection: [
+          "$WEB3",  // uses pre existing web3 object if available (e.g in Mist)
+          "ws://localhost:8546",
+          "http://localhost:8545"
+        ],
+        gas: "auto",
+      }
+    ```
 1. Deploy the contract with Embark:
 
     ``` sh


### PR DESCRIPTION
Fixed the interaction, development, tutorial instructions to
accomodate the protected Ethereum node API exposure.
Also fixed incorrect crosslinking to tutorials as they were mixed up.
Also added a config example to the embark asset tokenization tutorial.

Closes #80