### PR TITLE
Add copy-to-clipboard plugin

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -153,5 +153,6 @@ module.exports = {
         'sitemap': {
             hostname: 'https://docs.chainstack.com'
         },
+        '@dovyp/vuepress-plugin-clipboard-copy': true,
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,6 +820,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dovyp/vuepress-plugin-clipboard-copy": {
+      "version": "1.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@dovyp/vuepress-plugin-clipboard-copy/-/vuepress-plugin-clipboard-copy-1.0.0-alpha.7.tgz",
+      "integrity": "sha512-K+hgi4+tgQwz2ZlqpYTik5AFgDFZ1CcSYrMCqhicR1AwZ9kDsfbU+iD+NYSrsKXVTJJke/kzQIDsBFzcmC4Fkg=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vuepress": "^1.0.3"
   },
   "dependencies": {
+    "@dovyp/vuepress-plugin-clipboard-copy": "^1.0.0-alpha.7",
     "clean": "^4.0.2",
     "esm": "^3.2.25",
     "vuepress-plugin-clean-urls": "^1.0.3",


### PR DESCRIPTION
Added the copy-to-clipboard plugin that may be convenient to copy commands instead of selecting them, which may be a little challenging
for the longer ones.

The plugin looks for code blocks and shows the copy button with the code
language.

Closes #50