### PR TITLE
Mention that on-premise nodes are only available in hybrid networks

### DIFF
--- a/docs/platform/add-a-node-to-a-network.md
+++ b/docs/platform/add-a-node-to-a-network.md
@@ -2,7 +2,7 @@
 
 Once you have [deployed a consortium network](/platform/deploy-a-consortium-network) or [joined a public network](/platform/join-a-public-network), you can add more nodes to the network.
 
-For consortium networks, you can add a node to run in [cloud](/glossary/cloud) or [on-premises](/glossary/on-premises).
+For consortium networks, you can add a node to run in [cloud](/glossary/cloud) or [on-premises](/glossary/on-premises). On-premises nodes can only be deployed in [hybrid](/glossary/hybrid) networks. 
 
 For public networks, you can add a [shared](/glossary/shared-node) or a [dedicated](/glossary/dedicated-node) node.
 


### PR DESCRIPTION
Reason for this change is on a Cloud network, when you deploy a new node, there is only the option to select 'Cloud'. If you click 'Learn more', then you are brought to this page that explains that there is an On-prem option - but it's clearly not there in the UI, so we should explain why. 

