### PR TITLE
Various housekeeping

### DIFF
--- a/docs/blockchains/corda.md
+++ b/docs/blockchains/corda.md
@@ -143,5 +143,6 @@ There are also non-Corda Network Foundation managed compatibility zones. These a
 ::: tip See also
 
 * [Corda documentation](https://docs.corda.net)
+* [Build better with Corda](https://chainstack.com/build-better-with-corda/)
 
 :::

--- a/docs/blockchains/ethereum.md
+++ b/docs/blockchains/ethereum.md
@@ -12,5 +12,6 @@ For development purposes on the Ropsten testnet, fund your accounts with Ropsten
 ::: tip See also
 
 * [Operations: Ethereum](/operations/ethereum/)
+* [Build better with Ethereum](https://chainstack.com/build-better-with-ethereum/)
 
 :::

--- a/docs/blockchains/fabric.md
+++ b/docs/blockchains/fabric.md
@@ -65,5 +65,6 @@ See [Hyperledger Fabric 2.0: Smart Contracts and Chaincode](https://hyperledger-
 ::: tip See also
 
 * [Tools](/operations/fabric/tools)
+* [Build better with Hyperledger Fabric](https://chainstack.com/build-better-with-fabric/)
 
 :::

--- a/docs/glossary/hybrid.md
+++ b/docs/glossary/hybrid.md
@@ -1,3 +1,7 @@
 # Hybrid
 
 A hybrid deployment means that some nodes of the same network are [on-premises](/glossary/on-premises) while others are on the public [cloud](/glossary/cloud).
+
+::: warning
+Currently Chainstack supports only [MultiChain hybrid network deployment](/operations/multichain/deploying-a-hybrid-network).
+:::

--- a/docs/operations/ethereum/tools.md
+++ b/docs/operations/ethereum/tools.md
@@ -163,12 +163,6 @@ const web3 = new Web3(new Web3.providers.WebsocketProvider('wss://user-name:pass
 web3.eth.getBlockNumber().then(console.log);
 ```
 
-## Monitoring tools
-
-### Tenderly
-
-Monitor and debug your contracts with [Tenderly](https://tenderly.dev/).
-
 ::: tip See also
 
 * [Academic certificates with Truffle](/tutorials/ethereum/academic-certificates-with-truffle)

--- a/docs/operations/ethereum/tools.md
+++ b/docs/operations/ethereum/tools.md
@@ -165,65 +165,9 @@ web3.eth.getBlockNumber().then(console.log);
 
 ## Monitoring tools
 
-### TerminalSDK
+### Tenderly
 
-You can set up your DApp logging and analytics with TerminalSDK of [Terminal.co](https://terminal.co/) and Chainstack.
-
-1. Sign up with [Terminal.co](https://terminal.co/).
-1. Get your Terminal API key. See [Generating an API Key](https://docs.terminal.co/logs-analytics/create-an-api-key).
-1. Get your Terminal project ID. See [Locating the Project ID](https://docs.terminal.co/logs-analytics/locating-the-project-id).
-1. Install TerminalSDK. See [Installing TerminalSDK](https://docs.terminal.co/logs-analytics/hexsdk-quickstart#installing-terminalsdk).
-1. Wrap your Web3 instance with TerminalSDK:
-
-``` js
-const Web3 = require("web3");
-const {TerminalHttpProvider} = require("@terminal-packages/sdk");
-
-const web3 = new Web3(
-   new TerminalHttpProvider({
-    host: "https://USERNAME:PASSWORD@RPC_ENDPOINT",
-    apiKey: "TERMINAL_API_KEY",
-    projectId: "TERMINAL_PROJECT_ID",
-    source: "STRING"
-  })
-);
-```
-
-where
-
-* USERNAME — your Ethereum node access username.
-* PASSWORD — your Ethereum node access password.
-* RPC_ENDPOINT — your Ethereum node RPC endpoint.
-* TERMINAL_API_KEY — your Terminal.co API key.
-* TERMINAL_PROJECT_ID — your Terminal.co project ID.
-* STRING — any string that you will use to filter your logs at Terminal.co.
-
-Example to get an address balance and have it logged with Terminal.co:
-
-``` js
-const Web3 = require("web3");
-const {TerminalHttpProvider} = require("@terminal-packages/sdk");
-
-const web3 = new Web3(
-   new TerminalHttpProvider({
-    host: "https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com",
-    apiKey: "abcDfGhI1+JKl23MnOPQRS==",
-    projectId: "yuVXYZABcdeFgHIj",
-    source: "Chainstack"
-  })
-);
-const address = "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae";
-
-web3.eth.getBalance(address, (err, wei) => {
-  balance = web3.utils.fromWei(wei, "ether");
-  console.log(balance.toString(10));
-});
-```
-
-For information on how to view the logs and analytics, see:
-
-* [Logs Overview](https://docs.terminal.co/logs-analytics/logs-overview).
-* [Analytics Overview](https://docs.terminal.co/logs-analytics/analytics-overview)
+Monitor and debug your contracts with [Tenderly](https://tenderly.dev/).
 
 ::: tip See also
 

--- a/docs/operations/multichain/external-key-management.md
+++ b/docs/operations/multichain/external-key-management.md
@@ -10,7 +10,7 @@ External key management assumes that you do not store the keys in a MultiChain w
 
 This section will guide you through creating a key pair, issuing an asset and signing the transaction without keeping the private key in any wallet.
 
-You will call the MultiChain nodes running in the cloud. You can, however, do the transactions through a local node if you run a hybrid MultiChain network.
+You will call the MultiChain nodes running in the cloud. You can, however, do the transactions through a local node if you run a [hybrid](/glossary/hybrid) MultiChain network.
 
 1. Get your node access and credentials
 

--- a/docs/platform/supported-cloud-hosting-providers.md
+++ b/docs/platform/supported-cloud-hosting-providers.md
@@ -5,10 +5,6 @@ Chainstack currently supports the following cloud providers:
 * Google Cloud Platform
 * Amazon Web Services
 
-::: warning
-Currently only Asia-Pacific region hosting is supported.
-:::
-
 ::: tip
 Chainstack is always working on introducing support for other regions for cloud deployment.
 

--- a/docs/platform/supported-protocols.md
+++ b/docs/platform/supported-protocols.md
@@ -9,7 +9,7 @@ Consortium:
 
 Public network:
 
-* [Ethereum](/blockchains/ethereum) mainnet
+* [Ethereum](/blockchains/ethereum) mainnet. [Full and archive nodes](/operations/ethereum/modes).
 * [Ethereum](/blockchains/ethereum) Ropsten testnet
 * [Bitcoin](/blockchains/bitcoin) mainnet
 

--- a/docs/quickstart/create-a-project.md
+++ b/docs/quickstart/create-a-project.md
@@ -6,7 +6,7 @@ To create a project:
 
 1. Log in to your [Chainstack account](https://console.chainstack.com/).
 1. Click **Create project**.
-1. Click **Public chain** for an [Ethereum](/blockchains/ethereum) or [Bitcoin](/blockchains/bitcoin) node deployment, or **Consortium** for [Corda](/blockchains/corda), [Quorum](/blockchains/quorum), or [MultiChain](/blockchains/multichain).
+1. Click **Public chain** for an [Ethereum](/blockchains/ethereum) or [Bitcoin](/blockchains/bitcoin) node deployment, or **Consortium** for [Corda](/blockchains/corda), [Hyperledger Fabric](/blockchains/fabric), [Quorum](/blockchains/quorum), or [MultiChain](/blockchains/multichain).
 1. Provide **Project name** and optionally **Description**.
 1. Click **Create**.
 


### PR DESCRIPTION
Added build better pages.
Fixed the hybrid networks structure. Now it directs you to a hybrid network
glossary entry from various places in the docs. The entry says currently only
MultiChain hybrid is supported with a link to the guide.
Removed Terminal SDK. Added Tenderly.
Fixed other minor issues.