### PR TITLE
Add a note on deploying consortium Corda

### DIFF
--- a/docs/operations/corda/README.md
+++ b/docs/operations/corda/README.md
@@ -2,4 +2,4 @@
 
 This section outlines the fundamentals of and operations for Corda.
 
-Learn how to [connect Corda Explorer](/operations/corda/node-explorer) to your node, [install a CorDapp](/operations/corda/installing-a-cordapp), and [interact with the node](/operations/corda/tools) and the installed CorDapps.
+Learn what [networks](/operations/corda/networks) you can join or deploy, [connect Corda Explorer](/operations/corda/node-explorer) to your node, [install a CorDapp](/operations/corda/installing-a-cordapp), and [interact with the node](/operations/corda/tools) and the installed CorDapps.

--- a/docs/operations/corda/networks.md
+++ b/docs/operations/corda/networks.md
@@ -5,9 +5,12 @@ Chainstack supports joining the following Corda networks:
 * [Corda Network](https://corda.network/) — the production Corda network.
 * [Corda Pre-Production Network](https://corda.network/participation/preprod) — the pre-production Corda network.
 
+See [Join a public network](/platform/join-a-public-network).
+
+You can also deploy your own Corda network. See [Deploy a consortium network](/platform/deploy-a-consortium-network).
+
 ::: tip See also
 
 * [Manage your organization's identity](/platform/manage-your-organization-identity)
-* [Join a public network](/platform/join-a-public-network)
 
 :::


### PR DESCRIPTION
Made it clear that you can both join and deploy Corda networks
in the introduction and the list of networks.