### PR TITLE
Add alternative Ropsten faucets. Link to KB

### DIFF
--- a/docs/blockchains/ethereum.md
+++ b/docs/blockchains/ethereum.md
@@ -15,7 +15,7 @@ Chainstack currently supports joining the following Ethereum networks:
 * Mainnet — public Ethereum mainnet.
 * Ropsten testnet — public Ethereum testnet.
 
-For development purposes on the Ropsten testnet, fund your accounts with Ropsten ether at the [Ropsten faucet](https://faucet.ropsten.be/).
+For development purposes on the Ropsten testnet, fund your accounts with <a href="https://support.chainstack.com/hc/en-us/articles/900001458966-Ethereum-Ropsten-faucets" target="_blank">Ropsten ether</a>.
 
 ::: tip See also
 

--- a/docs/operations/ethereum/networks.md
+++ b/docs/operations/ethereum/networks.md
@@ -13,7 +13,7 @@ Chainstack supports joining the following Ethereum networks:
 * Mainnet — public Ethereum mainnet.
 * Ropsten testnet — public Ethereum testnet.
 
-For development purposes on the Ropsten testnet, fund your accounts with Ropsten ether at the [Ropsten faucet](https://faucet.ropsten.be/).
+For development purposes on the Ropsten testnet, fund your accounts with <a href="https://support.chainstack.com/hc/en-us/articles/900001458966-Ethereum-Ropsten-faucets" target="_blank">Ropsten ether</a>.
 
 ::: tip See also
 

--- a/docs/tutorials/ethereum/asset-tokenization-with-embark.md
+++ b/docs/tutorials/ethereum/asset-tokenization-with-embark.md
@@ -104,9 +104,9 @@ You will use this account to deploy the contract.
 
 ### Import the account in MetaMask and fund the account
 
-1. In MetaMask, click **Import Account** > **JSON FIle**.
+1. In MetaMask, click **Import Account** > **JSON File**.
 1. Select the keystore file that you created earlier.
-1. Fund the account with Ropsten ether at [Ropsten Ethereum Faucet](https://faucet.ropsten.be/).
+1. Fund the account with <a href="https://support.chainstack.com/hc/en-us/articles/900001458966-Ethereum-Ropsten-faucets" target="_blank">Ropsten ether</a>.
 
 ### Deploy the contract
 

--- a/docs/tutorials/ethereum/trust-fund-account-with-remix.md
+++ b/docs/tutorials/ethereum/trust-fund-account-with-remix.md
@@ -72,7 +72,7 @@ Having set up your MetaMask to interact through a Chainstack node, your Remix ID
 
 Create at least two accounts in MetaMask. You need two accounts to transfer the contract ownership from one to another.
 
-In your MetaMask, fund each account with Ropsten ether by clicking **Deposit** > **Test Faucet** > **Get Ether**.
+In your MetaMask, fund each account with <a href="https://support.chainstack.com/hc/en-us/articles/900001458966-Ethereum-Ropsten-faucets" target="_blank">Ropsten ether</a> by clicking **Deposit** > **Test Faucet** > **Get Ether**.
 
 ### Create and compile the Trust Fund smart contract
 


### PR DESCRIPTION
The more well-known ropsten.be faucet was glitchy recently
and not sending ropsten ether for days, so I had to look for other faucets
that work.
Added a KB article with two faucets so that people can get ropsten if one is down.
Linked all ropsten faucet mentions from the docs to the kb article to maintain
the list in one place.