### PR TITLE
Add default network id for quorum, chainname for multichain

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -86,6 +86,7 @@ module.exports = {
                             '/operations/quorum/',
                             '/operations/quorum/configuring-consensus',
                             '/operations/quorum/default-addresses',
+                            '/operations/quorum/default-network-id',
                             '/operations/quorum/key-management',
                             '/operations/quorum/tools',
                         ]
@@ -96,6 +97,7 @@ module.exports = {
                         children: [
                             '/operations/multichain/',
                             '/operations/multichain/default-addresses',
+                            '/operations/multichain/default-chain-name',
                             '/operations/multichain/node-permissions',
                             '/operations/multichain/external-key-management',
                             '/operations/multichain/cold-node-key-management',

--- a/docs/operations/multichain/cold-node-key-management.md
+++ b/docs/operations/multichain/cold-node-key-management.md
@@ -28,7 +28,7 @@ See [Download and Install MultiChain](https://www.multichain.com/download-instal
 
    1. Create a `~/.multichain-cold` directory on the server
 
-   1. In the `~/.multichain-cold` directory, create a subdirectory with the chain name. See [View node access and credentials](/platform/view-node-access-and-credentials) to get the chain name of your MultiChain network running with Chainstack.
+   1. In the `~/.multichain-cold` directory, create a subdirectory with the chain name. See [Default chain name](/operations/multichain/default-chain-name).
 
       Example: `~/.multichain-cold/nw-123-456-7`.
 
@@ -152,7 +152,7 @@ See [Download and Install MultiChain](https://www.multichain.com/download-instal
 
 where
 
-* CHAIN_NAME — your MultiChain network chain name. See [View node access and credentials](/platform/view-node-access-and-credentials).
+* CHAIN_NAME — your MultiChain network chain name. See [Default chain name](/operations/multichain/default-chain-name).
 
 Example:
 

--- a/docs/operations/multichain/default-chain-name.md
+++ b/docs/operations/multichain/default-chain-name.md
@@ -12,7 +12,7 @@ The default chain name of your MultiChain network deployed with Chainstack is th
 
 The network ID is part of the link that you get when opening your deployed network in your browser.
 
-For example, in `https://chainstack.com/projects/PR-123-456/networks/NW-123-456-7` the network ID and the chain name is `nw-123-456-7`. Note that you need switch the chain name to lower case.
+For example, in `https://chainstack.com/projects/PR-123-456/networks/NW-123-456-7` the network ID is `NW-123-456-7` and the chain name is `nw-123-456-7`.
 
 ::: tip See also
 

--- a/docs/operations/multichain/default-chain-name.md
+++ b/docs/operations/multichain/default-chain-name.md
@@ -8,7 +8,11 @@ meta:
 
 # Default chain name
 
-The default chain name of your MultiChain network deployed with Chainstack is `nw-123-456-7`.
+The default chain name of your MultiChain network deployed with Chainstack is the network ID. 
+
+The network ID is part of the link that you get when opening your deployed network in your browser.
+
+For example, in `https://chainstack.com/projects/PR-123-456/networks/NW-123-456-7` the network ID and the chain name is `NW-123-456-7`.
 
 ::: tip See also
 

--- a/docs/operations/multichain/default-chain-name.md
+++ b/docs/operations/multichain/default-chain-name.md
@@ -12,7 +12,7 @@ The default chain name of your MultiChain network deployed with Chainstack is th
 
 The network ID is part of the link that you get when opening your deployed network in your browser.
 
-For example, in `https://chainstack.com/projects/PR-123-456/networks/NW-123-456-7` the network ID and the chain name is `NW-123-456-7`.
+For example, in `https://chainstack.com/projects/PR-123-456/networks/NW-123-456-7` the network ID and the chain name is `nw-123-456-7`. Note that you need switch the chain name to lower case.
 
 ::: tip See also
 

--- a/docs/operations/multichain/default-chain-name.md
+++ b/docs/operations/multichain/default-chain-name.md
@@ -8,7 +8,7 @@ meta:
 
 # Default chain name
 
-The default chain name of your MultiChain network deployed with Chainstack is the network ID. 
+The default chain name of your MultiChain network deployed with Chainstack is the network ID in lower case. 
 
 The network ID is part of the link that you get when opening your deployed network in your browser.
 

--- a/docs/operations/multichain/default-chain-name.md
+++ b/docs/operations/multichain/default-chain-name.md
@@ -1,0 +1,18 @@
+---
+meta:
+  - name: description
+    content: The default chain name of a MultiChain network deployed with Chainstack.
+  - name: keywords
+    content: multichain default chain name
+---
+
+# Default chain name
+
+The default chain name of your MultiChain network deployed with Chainstack is `nw-123-456-7`.
+
+::: tip See also
+
+* [Default addresses](/operations/multichain/default-addresses)
+* [View node access and credentials](/platform/view-node-access-and-credentials)
+
+:::

--- a/docs/operations/multichain/deploying-a-hybrid-network.md
+++ b/docs/operations/multichain/deploying-a-hybrid-network.md
@@ -68,7 +68,7 @@ multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 
 where
 
-* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Access and credentials** > **Chain name**.
+* CHAIN_NAME — your cloud MultiChain network chain name. See [Default chain name](/operations/multichain/default-chain-name).
 * HOSTNAME — your cloud MultiChain node hostname.
   * Get your RPC hostname under **Access and credentials** as part of **RPC endpoint**.
   * Get your Organization ID on your [Organization Settings](https://console.chainstack.com/user/settings/organization) page.
@@ -176,7 +176,7 @@ multichaind CHAIN_NAME@HOSTNAME:PORT -daemon
 
 where
 
-* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Access and credentials** > **Chain name**.
+* CHAIN_NAME — your cloud MultiChain network chain name. See [Default chain name](/operations/multichain/default-chain-name).
 * HOSTNAME — your cloud MultiChain node hostname.
   * Get your RPC hostname under **Access and credentials** as part of **RPC endpoint**.
   * Get your Organization ID on your [Organization Settings](https://console.chainstack.com/user/settings/organization) page.
@@ -205,7 +205,7 @@ multichain-cli CHAIN_NAME
 
 where
 
-* CHAIN_NAME — your cloud MultiChain network chain name. Available under **Access and credentials** > **Chain name**.
+* CHAIN_NAME — your cloud MultiChain network chain name. See [Default chain name](/operations/multichain/default-chain-name).
 
 Command example:
 

--- a/docs/operations/quorum/default-network-id.md
+++ b/docs/operations/quorum/default-network-id.md
@@ -1,0 +1,18 @@
+---
+meta:
+  - name: description
+    content: The default network ID of a Quorum network deployed with Chainstack.
+  - name: keywords
+    content: quorum default network id
+---
+
+# Default network ID
+
+The default network ID of your Quorum network deployed with Chainstack is `10001`.
+
+::: tip See also
+
+* [Default addresses](/operations/quorum/default-addresses)
+* [View node access and credentials](/platform/view-node-access-and-credentials)
+
+:::

--- a/docs/operations/quorum/tools.md
+++ b/docs/operations/quorum/tools.md
@@ -120,7 +120,7 @@ where
 * `HDWalletProvider` — Truffle's custom provider to sign transactions.
 * `mnemonic` — your mnemonic that generates your accounts. You can also generate a mnemonic online with [Mnemonic Code Converter](https://iancoleman.io/bip39/). Make sure you generate a 15 word mnemonic.
 * RPC_ENDPOINT — your Quorum node RPC endpoint. The format is `https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com`. See [View node access and credentials](/platform/view-node-access-and-credentials).
-* `network_id` — your Quorum network ID. Available under **Access and credentials** > **Network ID**. You can set it to `*` for any.
+* `network_id` — your Quorum network ID. See [Default network ID](/operations/quorum/default-network-id). You can set it to `*` for any.
 * `gasPrice` — the setting must be `0` for the Quorum network.
 * `gas` — the setting must be the default `4500000` for the Quorum network.
 * `type` — the setting must be `quorum` to instruct Truffle for the Quorum network deployment.

--- a/docs/tutorials/multichain/distributed-company-scrips.md
+++ b/docs/tutorials/multichain/distributed-company-scrips.md
@@ -132,7 +132,6 @@ where
 * WALLET_ADDRESS_USER_n — member's address as part of this system. You and anyone can view any member's address under **Access and credentials** > **Default wallet address**.
 * TOKEN_NAME — the token name that you set up at [the previous step](#issue-a-company-token).
 * QUANTITY — the amount of tokens to transfer.
-* CHAIN_NAME — your MultiChain network chain name. Available under **Access and credentials** > **Chain name**.
 
 Example command:
 

--- a/docs/tutorials/quorum/food-supply-temperature-control-with-web3.md
+++ b/docs/tutorials/quorum/food-supply-temperature-control-with-web3.md
@@ -177,7 +177,7 @@ where
 * DEFAULT_WALLET_PRIVATE_KEY — a private key to your Quorum node default wallet address to sign the transaction. Available under **Access and credentials** > **Default wallet private key**.
 * TRANSACTION_MANAGER_PUBLIC_KEY — your Quorum node Tessera public key. The contract will use this key to make the contract private for the node that signs the contract transaction with the Tessera private key from this public-private key pair. Available under **Access and credentials** > **Transaction manager public key**.
 * TRANSACTION_MANAGER_ENDPOINT — an endpoint to the Tessera node deployed with your Quorum node. The format is `https://user-name:pass-word-pass-word-pass-word@tm-api-nd-123-456-789.p2pify.com`. Available under **Access and credentials** > **Transaction manager endpoint**.
-* NETWORK_ID — your Quorum network ID. Use the default ID `10001`.
+* NETWORK_ID — your Quorum network ID. See [Default network ID](/operations/quorum/default-network-id).
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 

--- a/docs/tutorials/quorum/loyalty-program-with-truffle.md
+++ b/docs/tutorials/quorum/loyalty-program-with-truffle.md
@@ -223,7 +223,7 @@ where
 * `HDWalletProvider` — Truffle's custom provider to sign transactions.
 * `mnemonic` — your mnemonic that generates your accounts. You can also generate a mnemonic online with [Mnemonic Code Converter](https://iancoleman.io/bip39/). Make sure you generate a 15 word mnemonic.
 * RPC_ENDPOINT — your Quorum node RPC endpoint. The format is `https://user-name:pass-word-pass-word-pass-word@nd-123-456-789.p2pify.com`. See [View node access and credentials](/platform/view-node-access-and-credentials).
-* `network_id` — your Quorum network ID. Available under **Access and credentials** > **Network ID**. You can set it to `*` for any.
+* `network_id` — your Quorum network ID. See [Default network ID](/operations/quorum/default-network-id). You can set it to `*` for any.
 * `gasPrice` — the setting must be `0` for the Quorum network.
 * `gas` — the setting must be the default `4500000` for the Quorum network.
 * `type` — the setting must be `quorum` to instruct Truffle for the Quorum network deployment.


### PR DESCRIPTION
Added the default chain name multichain.
Added the default network id for quorum.
Did crosslinking.
Removed the chain_name parameter mention from the multichain tutorial as it's not used there.

Closes #245