### PR TITLE
Update fabric-tools docker image command to 2.2.0 + polish

### DIFF
--- a/docs/blockchains/fabric.md
+++ b/docs/blockchains/fabric.md
@@ -25,7 +25,7 @@ Raft — a [CFT](/glossary/cft) consensus implementation in [etcd](https://etcd.
 
 Hyperledger Fabric uses [orderer nodes](#ordering-service) to form consensus.
 
-See [Hyperledger Fabric v2: Raft concepts](https://hyperledger-fabric.readthedocs.io/en/latest/orderer/ordering_service.html#raft-concepts).
+See [Hyperledger Fabric: Raft concepts](https://hyperledger-fabric.readthedocs.io/en/latest/orderer/ordering_service.html#raft-concepts).
 
 ## Network structure
 
@@ -47,19 +47,19 @@ Each peer has two communication interfaces:
 * Peer to peer communication that implements [gossip data dissemination protocol](https://hyperledger-fabric.readthedocs.io/en/latest/gossip.html) over [TLS](https://hyperledger-fabric.readthedocs.io/en/latest/enable_tls.html).
 * Node to owner communication implemented as gRPC.
 
-See [Hyperledger Fabric v2: Peers](https://hyperledger-fabric.readthedocs.io/en/latest/peers/peers.html).
+See [Hyperledger Fabric: Peers](https://hyperledger-fabric.readthedocs.io/en/latest/peers/peers.html).
 
 ### Certificate Authority
 
 The Certificate Authority component manages the digital identities of the Hyperledger Fabric network participants.
 
-See [Hyperledger Fabric v2: Certificate Authorities](https://hyperledger-fabric.readthedocs.io/en/latest/identity/identity.html#certificate-authorities).
+See [Hyperledger Fabric: Certificate Authorities](https://hyperledger-fabric.readthedocs.io/en/latest/identity/identity.html#certificate-authorities).
 
 ### Membership Service Provider
 
 The Membership Service Provider component identifies the network participants, their roles, and access privileges based on the Certificate Authority and by listing the participant identities.
 
-See [Hyperledger Fabric v2: Membership](https://hyperledger-fabric.readthedocs.io/en/latest/membership/membership.html).
+See [Hyperledger Fabric: Membership](https://hyperledger-fabric.readthedocs.io/en/latest/membership/membership.html).
 
 ### Ordering service
 
@@ -67,13 +67,13 @@ Any transaction in a Hyperledger Fabric network goes through the ordering servic
 
 The ordering service consists of orderer nodes. The orderer nodes form the Raft consensus of the network.
 
-See [Hyperledger Fabric v2: The Ordering Service](https://hyperledger-fabric.readthedocs.io/en/latest/orderer/ordering_service.html).
+See [Hyperledger Fabric: The Ordering Service](https://hyperledger-fabric.readthedocs.io/en/latest/orderer/ordering_service.html).
 
 ## Chaincode
 
 In Hyperledger Fabric terminology, a packaged and deployed smart contract is called a chaincode.
 
-See [Hyperledger Fabric v2: Smart Contracts and Chaincode](https://hyperledger-fabric.readthedocs.io/en/latest/smartcontract/smartcontract.html).
+See [Hyperledger Fabric: Smart Contracts and Chaincode](https://hyperledger-fabric.readthedocs.io/en/latest/smartcontract/smartcontract.html).
 
 ::: tip See also
 

--- a/docs/blockchains/fabric.md
+++ b/docs/blockchains/fabric.md
@@ -25,7 +25,7 @@ Raft — a [CFT](/glossary/cft) consensus implementation in [etcd](https://etcd.
 
 Hyperledger Fabric uses [orderer nodes](#ordering-service) to form consensus.
 
-See [Hyperledger Fabric 2.0: Raft concepts](https://hyperledger-fabric.readthedocs.io/en/release-2.0/orderer/ordering_service.html#raft-concepts).
+See [Hyperledger Fabric v2: Raft concepts](https://hyperledger-fabric.readthedocs.io/en/latest/orderer/ordering_service.html#raft-concepts).
 
 ## Network structure
 
@@ -44,22 +44,22 @@ Peers host ledgers and [chaincodes](#chaincode).
 
 Each peer has two communication interfaces:
 
-* Peer to peer communication that implements [gossip data dissemination protocol](https://hyperledger-fabric.readthedocs.io/en/release-2.0/gossip.html) over [TLS](https://hyperledger-fabric.readthedocs.io/en/release-2.0/enable_tls.html).
+* Peer to peer communication that implements [gossip data dissemination protocol](https://hyperledger-fabric.readthedocs.io/en/latest/gossip.html) over [TLS](https://hyperledger-fabric.readthedocs.io/en/latest/enable_tls.html).
 * Node to owner communication implemented as gRPC.
 
-See [Hyperledger Fabric 2.0: Peers](https://hyperledger-fabric.readthedocs.io/en/release-2.0/peers/peers.html).
+See [Hyperledger Fabric v2: Peers](https://hyperledger-fabric.readthedocs.io/en/latest/peers/peers.html).
 
 ### Certificate Authority
 
 The Certificate Authority component manages the digital identities of the Hyperledger Fabric network participants.
 
-See [Hyperledger Fabric 2.0: Certificate Authorities](https://hyperledger-fabric.readthedocs.io/en/release-2.0/identity/identity.html#certificate-authorities).
+See [Hyperledger Fabric v2: Certificate Authorities](https://hyperledger-fabric.readthedocs.io/en/latest/identity/identity.html#certificate-authorities).
 
 ### Membership Service Provider
 
 The Membership Service Provider component identifies the network participants, their roles, and access privileges based on the Certificate Authority and by listing the participant identities.
 
-See [Hyperledger Fabric 2.0: Membership](https://hyperledger-fabric.readthedocs.io/en/release-2.0/membership/membership.html).
+See [Hyperledger Fabric v2: Membership](https://hyperledger-fabric.readthedocs.io/en/latest/membership/membership.html).
 
 ### Ordering service
 
@@ -67,13 +67,13 @@ Any transaction in a Hyperledger Fabric network goes through the ordering servic
 
 The ordering service consists of orderer nodes. The orderer nodes form the Raft consensus of the network.
 
-See [Hyperledger Fabric 2.0: The Ordering Service](https://hyperledger-fabric.readthedocs.io/en/release-2.0/orderer/ordering_service.html).
+See [Hyperledger Fabric v2: The Ordering Service](https://hyperledger-fabric.readthedocs.io/en/latest/orderer/ordering_service.html).
 
 ## Chaincode
 
 In Hyperledger Fabric terminology, a packaged and deployed smart contract is called a chaincode.
 
-See [Hyperledger Fabric 2.0: Smart Contracts and Chaincode](https://hyperledger-fabric.readthedocs.io/en/release-2.0/smartcontract/smartcontract.html).
+See [Hyperledger Fabric v2: Smart Contracts and Chaincode](https://hyperledger-fabric.readthedocs.io/en/latest/smartcontract/smartcontract.html).
 
 ::: tip See also
 

--- a/docs/operations/fabric/tools.md
+++ b/docs/operations/fabric/tools.md
@@ -202,6 +202,25 @@ $ peer lifecycle chaincode approveformyorg --name fabcar --package-id fabcar:6ab
 2020-02-27 07:45:27.742 UTC [chaincodeCmd] ClientWait -> INFO 001 txid [817547cebd7dd66084e7ff852ca8cac35d0c505416a7787ddd81947558280dc7] committed with status (VALID)
 ```
 
+#### Query the approved chaincode
+
+``` sh
+$ peer lifecycle chaincode queryapproved --channelID CHANNEL_ID -n CHAINCODE_NAME
+```
+
+where
+
+* CHANNEL_ID — use `defaultchannel`.
+* CHAINCODE_NAME — name of your chaincode.
+
+Example:
+
+``` sh
+$ peer lifecycle chaincode queryapproved --channelID defaultchannel -n fabcar
+Approved chaincode definition for chaincode 'fabcar' on channel 'defaultchannel':
+sequence: 1, version: 1.0.0, init-required: true, package-id: fabcar:6ab145685b4602cf429f93536981ea3eab802369e6359fb841fb0a9bcd4a51fb, endorsement plugin: escc, validation plugin: vscc
+```
+
 #### Check the chaincode commit readiness
 
 ``` sh

--- a/docs/operations/fabric/tools.md
+++ b/docs/operations/fabric/tools.md
@@ -283,7 +283,7 @@ Name: fabcar, Version: 1.0.0, Sequence: 1, Endorsement Plugin: escc, Validation 
 
 ## Development tools
 
-See [Hyperledger Fabric v2: Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html).
+See [Hyperledger Fabric: Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html).
 
 ::: tip See also
 

--- a/docs/operations/fabric/tools.md
+++ b/docs/operations/fabric/tools.md
@@ -25,17 +25,19 @@ Interact with your Hyperledger Fabric peer using [the fabric-tools Docker contai
 
 This will export the peer and the organization certificates and the user in a ZIP archive. Unarchive the exported file.
 
+Unarchiving the exported file will create a directory named after your organization's MSP ID. For example, `RG-123-456-MSP`.
+
 #### Export the orderer certificate of your network
 
 1. In the platform UI, navigate to your network.
 1. Click **Details** > **Export orderer TLS certificate**.
 
-This will export the orderer certificate. Place the certificate in the directory that was created at the previous step.
+This will export the orderer certificate. Place the certificate in the directory that was created at the previous step when you unarchived the exported organization identity file.
 
 #### Run the fabric-tools Docker container
 
 ``` sh
-docker run -v /host/path/to/IDENTITY_DIRECTORY/:/MOUNT_DIRECTORY -it hyperledger/fabric-tools:2.0.1 /bin/ash
+docker run -v /host/path/to/IDENTITY_DIRECTORY/:/MOUNT_DIRECTORY -it hyperledger/fabric-tools:2.2.0 /bin/ash
 ```
 
 where
@@ -46,7 +48,7 @@ where
 Example:
 
 ``` sh
-docker run -v /home/user/RG-123-456-MSP/:/data -it hyperledger/fabric-tools:2.0.1 /bin/ash
+docker run -v /home/user/RG-123-456-MSP/:/data -it hyperledger/fabric-tools:2.2.0 /bin/ash
 ```
 
 #### Provide connection details and certificate paths
@@ -262,7 +264,7 @@ Name: fabcar, Version: 1.0.0, Sequence: 1, Endorsement Plugin: escc, Validation 
 
 ## Development tools
 
-See [Hyperledger Fabric 2.0: Developing Applications](https://hyperledger-fabric.readthedocs.io/en/release-2.0/developapps/developing_applications.html).
+See [Hyperledger Fabric v2: Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html).
 
 ::: tip See also
 


### PR DESCRIPTION
Updated the fabric-tools docker image command to 2.2.0.
Fixed links to hlf docs to the latest ones instead of the 2.0 version.
Updated the tools section to make it clear that when you unzip the exported org
identity, it created a directory.