### PR TITLE
Fix API reference link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -249,11 +249,11 @@ module.exports = {
             gtm: 'GTM-PXSGW6M'
         },
         'sitemap': {
-            hostname: (process.env.DOCS_HOSTNAME ? 'https://' + process.env.DOCS_HOSTNAME : 'http://localhost:8080')
+            hostname: `https://${process.env.DOCS_HOSTNAME}`,
         },
         '@limdongjin/vuepress-plugin-simple-seo': {
             default_image: '/img/social-image.png',
-            root_url: (process.env.DOCS_HOSTNAME ? 'https://' + process.env.DOCS_HOSTNAME : 'http://localhost:8080'),
+            root_url: `https://${process.env.DOCS_HOSTNAME}`,
             default_site_name: 'Chainstack documentation'
         },
         'check-md': {}

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -200,7 +200,7 @@ module.exports = {
                     '/blockchains/multichain',
                     '/blockchains/ethereum',
                     '/blockchains/bitcoin',
-                    ]
+                ]
             },
             {
                 title: 'Glossary',
@@ -225,7 +225,7 @@ module.exports = {
                     '/glossary/shared-node',
                     '/glossary/user',
                     '/glossary/vault',
-                    ]
+                ]
             },
         '/release-notes',
         ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,6 +9,7 @@ module.exports = {
     },
     themeConfig: {
         logo: '/img/docs-logo.svg',
+        apiDocsURL: `https://${process.env.DOCS_HOSTNAME}/api/reference/`,
         nav: [
             { text: 'Support', link: 'https://support.chainstack.com' },
             { text: 'Log in', link: 'https://console.chainstack.com/user/login' },
@@ -185,8 +186,8 @@ module.exports = {
                     '/api/',
                     '/api/create-api-keys',
                     '/api/delete-api-keys',
-                    '/api/reference/',
-                    ]
+                    [`https://${process.env.DOCS_HOSTNAME}/api/reference/`, 'API reference'],
+                ]
             },
             {
                 title: 'Blockchains',

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -17,4 +17,4 @@ Chainstack API allows you to manage:
 
 To start with the API, you must [create API keys](/api/create-api-keys).
 
-For all available API operations, see [API reference](/api/reference/).
+For all available API operations, see <a :href="$themeConfig.apiDocsURL" target="_blank">API reference</a>.

--- a/docs/api/create-api-keys.md
+++ b/docs/api/create-api-keys.md
@@ -25,7 +25,7 @@ Make sure you keep the API key secure.
 
 ::: tip See also
 
-* [API reference](/api/reference/)
+* <a :href="$themeConfig.apiDocsURL" target="_blank">API reference</a>
 * [Delete API keys](/api/delete-api-keys)
 
 :::

--- a/docs/api/delete-api-keys.md
+++ b/docs/api/delete-api-keys.md
@@ -19,6 +19,6 @@ To delete an API key:
 ::: tip See also
 
 * [Create API keys](/api/create-api-keys)
-* [API reference](/api/reference/)
+* <a :href="$themeConfig.apiDocsURL" target="_blank">API reference</a>
 
 :::

--- a/docs/api/reference/README.md
+++ b/docs/api/reference/README.md
@@ -1,3 +1,0 @@
-# API reference
-
-Dummy page for VuePress, the API reference is served via [ReDoc](https://github.com/chainstack/api).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vuepress build docs",
     "check-md": "vuepress check-md docs",
     "clean": "rm -rf docs/.vuepress/dist",
-    "dev": "vuepress dev docs"
+    "dev": "DOCS_HOSTNAME=docs.dev.chainstack.com vuepress dev docs"
   },
   "devDependencies": {
     "markdown-it-container": "^2.0.0",


### PR DESCRIPTION
Currently, link goes to the dummy page instead of API ref.

Signed-off-by: Anton Zaslavskiy <anton.zaslavskiy@chainstack.com>