### PR TITLE
Add service nodes for docs helpers UI

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -70,6 +70,7 @@ module.exports = {
                         children: [
                             '/operations/corda/',
                             '/operations/corda/networks',
+                            '/operations/corda/service-nodes',
                             '/operations/corda/node-explorer',
                             '/operations/corda/installing-a-cordapp',
                             '/operations/corda/tools',
@@ -79,6 +80,7 @@ module.exports = {
                         title: 'Hyperledger Fabric',
                         collapsable: true,
                         children: [
+                            '/operations/fabric/service-nodes',
                             '/operations/fabric/tools',
                         ]
                     },
@@ -91,6 +93,7 @@ module.exports = {
                             '/operations/quorum/default-addresses',
                             '/operations/quorum/default-network-id',
                             '/operations/quorum/key-management',
+                            '/operations/quorum/service-nodes',
                             '/operations/quorum/tools',
                         ]
                     },
@@ -105,6 +108,7 @@ module.exports = {
                             '/operations/multichain/external-key-management',
                             '/operations/multichain/cold-node-key-management',
                             '/operations/multichain/deploying-a-hybrid-network',
+                            '/operations/multichain/service-nodes',
                             '/operations/multichain/tools',
                         ]
                     },

--- a/docs/operations/corda/service-nodes.md
+++ b/docs/operations/corda/service-nodes.md
@@ -11,7 +11,7 @@ meta:
 A Corda network is deployed with the following service nodes:
 
 * Notary — a [notary node](/blockchains/corda#notary-service).
-* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) using the [Cordite tool](https://gitlab.com/cordite/network-map-service).
+* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) running [Cordite](https://gitlab.com/cordite/network-map-service).
 
 ::: tip See also
 

--- a/docs/operations/corda/service-nodes.md
+++ b/docs/operations/corda/service-nodes.md
@@ -11,9 +11,7 @@ meta:
 A Corda network is deployed with the following service nodes:
 
 * Notary — a [notary node](/blockchains/corda#notary-service).
-* Network Map Service — a [network map service node](/blockchains/corda#network-map-service).
-
-The service nodes are provided for free.
+* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) using the [Cordite Network Map Service](https://gitlab.com/cordite/network-map-service) tool.
 
 ::: tip See also
 

--- a/docs/operations/corda/service-nodes.md
+++ b/docs/operations/corda/service-nodes.md
@@ -11,7 +11,7 @@ meta:
 A Corda network is deployed with the following service nodes:
 
 * Notary — a [notary node](/blockchains/corda#notary-service).
-* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) using the [Cordite Network Map Service](https://gitlab.com/cordite/network-map-service) tool.
+* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) using the [Cordite tool](https://gitlab.com/cordite/network-map-service).
 
 ::: tip See also
 

--- a/docs/operations/corda/service-nodes.md
+++ b/docs/operations/corda/service-nodes.md
@@ -1,0 +1,22 @@
+---
+meta:
+  - name: description
+    content: Learn what service nodes come with the Corda deployment on Chainstack.
+  - name: keywords
+    content: corda node service notary map
+---
+
+# Service nodes
+
+A Corda network is deployed with the following service nodes:
+
+* Notary — a [notary node](/blockchains/corda#notary-service).
+* Network Map Service — a [network map service node](/blockchains/corda#network-map-service).
+
+The service nodes are provided for free.
+
+::: tip See also
+
+* [View service nodes](/platform/view-service-nodes)
+
+:::

--- a/docs/operations/corda/service-nodes.md
+++ b/docs/operations/corda/service-nodes.md
@@ -11,7 +11,7 @@ meta:
 A Corda network is deployed with the following service nodes:
 
 * Notary — a [notary node](/blockchains/corda#notary-service).
-* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) running [Cordite](https://gitlab.com/cordite/network-map-service).
+* Network Map Service — a [network map service node](/blockchains/corda#network-map-service) running [Cordite Network Map Service](https://gitlab.com/cordite/network-map-service).
 
 ::: tip See also
 

--- a/docs/operations/fabric/service-nodes.md
+++ b/docs/operations/fabric/service-nodes.md
@@ -10,7 +10,7 @@ meta:
 
 A Hyperledger Fabric network is deployed with the following service nodes:
 
-* Explorer — an explorer node using the [Hyperledger Explorer](https://www.hyperledger.org/use/explorer) tool. Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
+* Explorer — a node using the [Hyperledger Explorer](https://www.hyperledger.org/use/explorer) tool to scan and view the network. Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
 * Orderer — an [ordering service node](/blockchains/fabric#ordering-service).
 
 ::: tip See also

--- a/docs/operations/fabric/service-nodes.md
+++ b/docs/operations/fabric/service-nodes.md
@@ -10,10 +10,8 @@ meta:
 
 A Hyperledger Fabric network is deployed with the following service nodes:
 
-* Explorer — an explorer node.
+* Explorer — an explorer node using the [Hyperledger Explorer](https://www.hyperledger.org/use/explorer) tool. Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
 * Orderer — an [ordering service node](/blockchains/fabric#ordering-service).
-
-The service nodes are provided for free.
 
 ::: tip See also
 

--- a/docs/operations/fabric/service-nodes.md
+++ b/docs/operations/fabric/service-nodes.md
@@ -1,0 +1,22 @@
+---
+meta:
+  - name: description
+    content: Learn what service nodes come with the Hyperledger Fabric deployment on Chainstack.
+  - name: keywords
+    content: hyperledger fabric node service explorer orderer
+---
+
+# Service nodes
+
+A Hyperledger Fabric network is deployed with the following service nodes:
+
+* Explorer — an explorer node.
+* Orderer — an [ordering service node](/blockchains/fabric#ordering-service).
+
+The service nodes are provided for free.
+
+::: tip See also
+
+* [View service nodes](/platform/view-service-nodes)
+
+:::

--- a/docs/operations/fabric/service-nodes.md
+++ b/docs/operations/fabric/service-nodes.md
@@ -10,7 +10,7 @@ meta:
 
 A Hyperledger Fabric network is deployed with the following service nodes:
 
-* Explorer — a node running [Hyperledger Explorer](https://www.hyperledger.org/use/explorer) to scan and view the network. Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
+* Explorer — a node running [Hyperledger Explorer](https://www.hyperledger.org/use/explorer). Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
 * Orderer — an [ordering service node](/blockchains/fabric#ordering-service).
 
 ::: tip See also

--- a/docs/operations/fabric/service-nodes.md
+++ b/docs/operations/fabric/service-nodes.md
@@ -10,7 +10,7 @@ meta:
 
 A Hyperledger Fabric network is deployed with the following service nodes:
 
-* Explorer — a node using the [Hyperledger Explorer](https://www.hyperledger.org/use/explorer) tool to scan and view the network. Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
+* Explorer — a node running [Hyperledger Explorer](https://www.hyperledger.org/use/explorer) to scan and view the network. Each organization participating in a Hyperledger Fabric network has its own explorer node deployed.
 * Orderer — an [ordering service node](/blockchains/fabric#ordering-service).
 
 ::: tip See also

--- a/docs/operations/multichain/service-nodes.md
+++ b/docs/operations/multichain/service-nodes.md
@@ -10,9 +10,7 @@ meta:
 
 A MultiChain network is deployed with the following service node:
 
-* Explorer — an explorer node.
-
-The service node is provided for free.
+* Explorer — an explorer node using the [MultiChain explorer](https://github.com/chainstack/multichain-explorer).
 
 ::: tip See also
 

--- a/docs/operations/multichain/service-nodes.md
+++ b/docs/operations/multichain/service-nodes.md
@@ -1,0 +1,21 @@
+---
+meta:
+  - name: description
+    content: Learn what service nodes come with the MultiChain deployment on Chainstack.
+  - name: keywords
+    content: multichain node service explorer
+---
+
+# Service nodes
+
+A MultiChain network is deployed with the following service node:
+
+* Explorer — an explorer node.
+
+The service node is provided for free.
+
+::: tip See also
+
+* [View service nodes](/platform/view-service-nodes)
+
+:::

--- a/docs/operations/multichain/service-nodes.md
+++ b/docs/operations/multichain/service-nodes.md
@@ -10,7 +10,7 @@ meta:
 
 A MultiChain network is deployed with the following service node:
 
-* Explorer — an explorer node using the [MultiChain explorer](https://github.com/chainstack/multichain-explorer).
+* Explorer — a node running [MultiChain explorer](https://github.com/chainstack/multichain-explorer).
 
 ::: tip See also
 

--- a/docs/operations/quorum/service-nodes.md
+++ b/docs/operations/quorum/service-nodes.md
@@ -10,7 +10,7 @@ meta:
 
 A Quorum network is deployed with the following service node:
 
-* Explorer — an explorer node using the [Epirus explorer](https://github.com/blk-io/epirus-free).
+* Explorer — a node running [Epirus explorer](https://github.com/blk-io/epirus-free).
 
 ::: tip See also
 

--- a/docs/operations/quorum/service-nodes.md
+++ b/docs/operations/quorum/service-nodes.md
@@ -10,9 +10,7 @@ meta:
 
 A Quorum network is deployed with the following service node:
 
-* Explorer — an explorer node.
-
-The service node is provided for free.
+* Explorer — an explorer node using the [Epirus explorer](https://github.com/blk-io/epirus-free).
 
 ::: tip See also
 

--- a/docs/operations/quorum/service-nodes.md
+++ b/docs/operations/quorum/service-nodes.md
@@ -1,0 +1,21 @@
+---
+meta:
+  - name: description
+    content: Learn what service nodes come with the Quorum deployment on Chainstack.
+  - name: keywords
+    content: quorum node service explorer
+---
+
+# Service nodes
+
+A Quorum network is deployed with the following service node:
+
+* Explorer — an explorer node.
+
+The service node is provided for free.
+
+::: tip See also
+
+* [View service nodes](/platform/view-service-nodes)
+
+:::

--- a/docs/platform/view-service-nodes.md
+++ b/docs/platform/view-service-nodes.md
@@ -19,28 +19,11 @@ To view service nodes:
 1. Click **Service nodes**.
 1. Click the node name.
 
-Corda service nodes:
-
-* Notary — a [notary node](/blockchains/corda#notary-service).
-* Network Map Service — a [network map service node](/blockchains/corda#network-map-service).
-
-Hyperledger Fabric service nodes:
-
-* Explorer — an explorer node.
-* Orderer — an [ordering service node](/blockchains/fabric#ordering-service).
-
-Quorum service nodes:
-
-* Explorer — an explorer node.
-
-MultiChain service nodes:
-
-* Explorer — an explorer node.
-
 ::: tip See also
 
-* [View node and network status](/platform/view-node-and-network-status)
-* [View node resources allocation](/platform/view-node-resources-allocation)
-* [View activity log](/platform/view-activity-log)
+* [Corda service nodes](/operations/corda/service-nodes)
+* [Hyperledger Fabric service nodes](/operations/fabric/service-nodes)
+* [Quorum service nodes](/operations/quorum/service-nodes)
+* [MultiChain service nodes](/operations/multichain/service-nodes)
 
 :::


### PR DESCRIPTION
Added the service nodes sections for each of the consortium protocols.
It's also a good place to have them in case we change stuff / add more functionality
around service nodes in the future

Closes [UI #1938](https://github.com/chainstack/ui/issues/1938)