### PR TITLE
Fix HDwallet version

### DIFF
--- a/docs/tutorials/bsc/bep-1155-contract-with-truffle-and-openzeppelin.md
+++ b/docs/tutorials/bsc/bep-1155-contract-with-truffle-and-openzeppelin.md
@@ -119,12 +119,10 @@ This will create the contract deployment instructions for Truffle.
 
 [HDWalletProvider](https://github.com/trufflesuite/truffle/tree/develop/packages/hdwallet-provider) is Truffle's separate npm package used to sign transactions.
 
-For compatibility considerations, you must install version `1.2.3`.
-
 Run:
 
 ``` sh
-npm install @truffle/hdwallet-provider@1.2.3
+npm install @truffle/hdwallet-provider
 ```
 
 2. Edit `truffle-config.js` to add:


### PR DESCRIPTION
The HDWallet version has since been updated and users must use the
latest one for the tutorial to work with our Geth client BSC.

For context:
* [disable sending of non eip155 replay protected tx](https://github.com/ethereum/go-ethereum/pull/22339)
* [Issue in Truffle](https://github.com/trufflesuite/truffle/issues/3913)