### PR TITLE
Fix 16 blocks to 32

### DIFF
--- a/docs/operations/avalanche/modes.md
+++ b/docs/operations/avalanche/modes.md
@@ -15,7 +15,7 @@ Chainstack supports deploying an Avalanche node on the mainnet in the following 
 
 To be a part of the Avalanche mainnet, you can deploy either a full node or an archive node.
 
-With a full node, you can query the historical state of the Avalanche mainnet on C-Chain at only the latest 16 blocks.
+With a full node, you can query the historical state of the Avalanche mainnet on C-Chain at only the latest 32 blocks.
 
 To be able to query the historical state of the Avalanche mainnet on C-Chain at any block, you need an archive node.
 


### PR DESCRIPTION
It's 32 blocks back for states on the Avalanche C-Chain now in
the client software version that we support.
[Reference](https://github.com/ava-labs/coreth/blob/master/core/state_manager.go#L44)