### PR TITLE
CORE-4808 Updated Circle CI to push all tags of built image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ _job_build_image: &build_image
     - image: chainstack/builder:latest
   steps:
     - setup_remote_docker:
-       version: stable
+       version: 20.10.14
 
     - checkout
 
@@ -113,7 +113,7 @@ _job_build_image: &build_image
            -t ${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} .
          docker tag ${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} ${GOOGLE_GCR_HOSTNAME}/${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}
          docker tag ${GOOGLE_GCR_HOSTNAME}/${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} ${GOOGLE_GCR_HOSTNAME}/${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}:latest
-         docker push ${GOOGLE_GCR_HOSTNAME}/${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}
+         docker push -a ${GOOGLE_GCR_HOSTNAME}/${GOOGLE_PROJECT_ID}/${CIRCLE_PROJECT_REPONAME}
 
 jobs:
 


### PR DESCRIPTION
## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `Circle CI` to push **all** tags of built image.
2. Updated `docker:stable` to `docker:20.10.14`.


Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.

## Rationale
[Task: CORE-4808](https://chainstack.myjetbrains.com/youtrack/issue/CORE-4808/Fix-failing-Circle-CI-tests-in-docs)

