### PR TITLE
Sepolia

### DIFF
--- a/docs/blockchains/ethereum.md
+++ b/docs/blockchains/ethereum.md
@@ -14,6 +14,7 @@ Chainstack currently supports joining the following Ethereum networks:
 
 * Mainnet — public Ethereum mainnet.
 * Goerli testnet — a proof-of-stake public Ethereum testnet.
+* Sepolia testnet — a proof-of-stake public Ethereum testnet.
 * Ropsten testnet — a proof-of-work public Ethereum testnet.
 * Rinkeby testnet — a proof-of-authority public Ethereum testnet.
 

--- a/docs/operations/ethereum/networks.md
+++ b/docs/operations/ethereum/networks.md
@@ -12,6 +12,7 @@ Chainstack supports joining the following Ethereum networks:
 
 * Mainnet — public Ethereum mainnet.
 * Goerli testnet — a proof-of-stake public Ethereum testnet.
+* Sepolia testnet — a proof-of-stake public Ethereum testnet.
 * Ropsten testnet — a proof-of-stake public Ethereum testnet.
 * Rinkeby testnet — a proof-of-authority public Ethereum testnet.
 

--- a/docs/operations/ethereum/tools.md
+++ b/docs/operations/ethereum/tools.md
@@ -191,8 +191,9 @@ You can set your [MetaMask](https://metamask.io/) to interact through your Ether
     * Ropsten: `3`
     * Rinkeby: `4`
     * Goerli: `5`
+    * Sepolia: `11155111`
 
-1. Click **Save**.
+2. Click **Save**.
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -813,6 +814,7 @@ where
   * Ropsten: `3`
   * Rinkeby: `4`
   * Goerli: `5`
+  * Sepolia: `11155111`
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -869,6 +871,7 @@ where
   * Ropsten: `3`
   * Rinkeby: `4`
   * Goerli: `5`
+  * Sepolia: `11155111`
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -918,6 +921,7 @@ where
   * Ropsten: `3`
   * Rinkeby: `4`
   * Goerli: `5`
+  * Sepolia: `11155111`
 
 Example to add an Ethereum mainnet node to the list of Brownie networks:
 

--- a/docs/operations/ethereum/tools.md
+++ b/docs/operations/ethereum/tools.md
@@ -188,12 +188,12 @@ You can set your [MetaMask](https://metamask.io/) to interact through your Ether
 1. In the **Chain ID** field, enter the ID of the network:
 
     * Mainnet: `1`
-    * Ropsten: `3`
-    * Rinkeby: `4`
     * Goerli: `5`
     * Sepolia: `11155111`
+    * Ropsten: `3`
+    * Rinkeby: `4`
 
-2. Click **Save**.
+1. Click **Save**.
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -810,11 +810,11 @@ where
 * USERNAME — your node access username.
 * PASSWORD — your node access password.
 * NETWORK_ID — Ethereum network ID:
-  * Mainnet: `1`
-  * Ropsten: `3`
-  * Rinkeby: `4`
-  * Goerli: `5`
-  * Sepolia: `11155111`
+   * Mainnet: `1`
+   * Goerli: `5`
+   * Sepolia: `11155111`
+   * Ropsten: `3`
+   * Rinkeby: `4`
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -868,10 +868,10 @@ where
 * ENDPOINT — your node WSS endpoint.
 * NETWORK_ID — Ethereum network ID:
   * Mainnet: `1`
-  * Ropsten: `3`
-  * Rinkeby: `4`
   * Goerli: `5`
   * Sepolia: `11155111`
+  * Ropsten: `3`
+  * Rinkeby: `4`
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -917,11 +917,11 @@ where
 * NETWORK_NAME — any name that you want to identify the network by in the list if networks. For example, **Mainnet (Chainstack)**.
 * ENDPOINT — your node HTTPS or WSS endpoint.
 * NETWORK_ID — Ethereum network ID:
-  * Mainnet: `1`
-  * Ropsten: `3`
-  * Rinkeby: `4`
-  * Goerli: `5`
-  * Sepolia: `11155111`
+   * Mainnet: `1`
+   * Goerli: `5`
+   * Sepolia: `11155111`
+   * Ropsten: `3`
+   * Rinkeby: `4`
 
 Example to add an Ethereum mainnet node to the list of Brownie networks:
 

--- a/docs/platform/join-a-public-network.md
+++ b/docs/platform/join-a-public-network.md
@@ -12,7 +12,7 @@ meta:
 
 1. Select a [public chain project](/glossary/public-chain-project) and click **Get started** or **Join network**.
 1. Under **Blockchain protocol**, select **Ethereum**.
-1. Under **Blockchain network**, select **Mainnet**, **Ropsten testnet**, **Rinkeby testnet**, or **Goerli testnet**. Click **Next**.
+1. Under **Blockchain network**, select **Mainnet**, **Ropsten testnet**, **Rinkeby testnet**, **Goerli testnet**, or **Sepolia testnet**. Click **Next**.
 1. Under **Type**, select whether to run an [elastic](/glossary/elastic-node) or a [dedicated](/glossary/dedicated-node) node.
 1. Under **Mode**, select whether to run a full node or an archive node. See [Modes](/operations/ethereum/modes).
 1. If you are deploying a dedicated archive node, under **Client**, select whether to run a Geth node or an Erigon node. See [Clients](/operations/ethereum/clients).

--- a/docs/platform/join-a-public-network.md
+++ b/docs/platform/join-a-public-network.md
@@ -12,7 +12,7 @@ meta:
 
 1. Select a [public chain project](/glossary/public-chain-project) and click **Get started** or **Join network**.
 1. Under **Blockchain protocol**, select **Ethereum**.
-1. Under **Blockchain network**, select **Mainnet**, **Ropsten testnet**, **Rinkeby testnet**, **Goerli testnet**, or **Sepolia testnet**. Click **Next**.
+1. Under **Blockchain network**, select **Mainnet**, **Goerli testnet**, **Sepolia testnet**, **Ropsten testnet**, or **Rinkeby testnet**. Click **Next**.
 1. Under **Type**, select whether to run an [elastic](/glossary/elastic-node) or a [dedicated](/glossary/dedicated-node) node.
 1. Under **Mode**, select whether to run a full node or an archive node. See [Modes](/operations/ethereum/modes).
 1. If you are deploying a dedicated archive node, under **Client**, select whether to run a Geth node or an Erigon node. See [Clients](/operations/ethereum/clients).

--- a/docs/platform/supported-protocols.md
+++ b/docs/platform/supported-protocols.md
@@ -12,10 +12,10 @@ Public network:
 
 * [Ethereum](/blockchains/ethereum)
 	* Mainnet. [Full and archive nodes](/operations/ethereum/modes).
-	* Ropsten testnet
-	* Rinkeby testnet
 	* Goerli testnet
 	* Sepolia testnet
+	* Ropsten testnet
+	* Rinkeby testnet
 * [Polygon PoS](/blockchains/polygon)
 	* Mainnet. [Full and archive nodes](/operations/polygon/modes).
 	* Mumbai testnet

--- a/docs/platform/supported-protocols.md
+++ b/docs/platform/supported-protocols.md
@@ -15,6 +15,7 @@ Public network:
 	* Ropsten testnet
 	* Rinkeby testnet
 	* Goerli testnet
+	* Sepolia testnet
 * [Polygon PoS](/blockchains/polygon)
 	* Mainnet. [Full and archive nodes](/operations/polygon/modes).
 	* Mumbai testnet


### PR DESCRIPTION
Updated the docs to include references to the newly supported Ethereum Sepolia testnet network. Added the network and ChainID to the _Operations>Ethereum>Tools_ section. 