### PR TITLE
Fix Avalanche client desc - typos

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-3.5.14+{BUILD_NUM}
+3.5.15+{BUILD_NUM}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -32,3 +32,4 @@ See:
 * [Polygon API reference](/api/polygon/polygon-api-reference).
 * [Avalanche API reference](/api/avalanche/avalanche-api-reference).
 * [Arbitrum API reference](/api/arbitrum/arbitrum-api-reference).
+* [Solana API reference](/api/solana/solana-api-reference).

--- a/docs/blockchains/cronos.md
+++ b/docs/blockchains/cronos.md
@@ -12,9 +12,7 @@ Cronos is an open-source and permissionless, layer-1 Ethereum-compatible blockch
 
 ## Consensus
 
-Cronos Chain is based on Ethermint and is built on the [Tendermint](https://tendermint.com/) Proof of Stake (PoS) Core Consensus Engine, and the [Cosmos SDK](https://v1.cosmos.network/sdk).
-
-The Cronos consensus operates on a modified version of the Tendermint PoS consensus whereby validators are vetted by other validators, and are awarded staking tokens based on performance factors. The Cronos consensus is referred to as Proof of Authority (PoA) because new nodes require existing validators to authorize the provision of staking tokens to the new node validators.
+Cronos has the Proof of Authority (PoA) consensus. It operates on a modified version of the [Tendermint](https://tendermint.com/) Proof of Stake (PoS) consensus whereby validators are vetted by other validators, and are awarded staking tokens based on performance factors. The Cronos consensus is referred to as PoA because new nodes require existing validators to authorize the provision of staking tokens to the new node validators.
 
 ::: tip See also
 

--- a/docs/operations/avalanche/debug-and-trace-apis.md
+++ b/docs/operations/avalanche/debug-and-trace-apis.md
@@ -50,5 +50,8 @@ curl -H "Content-Type: application/json" -d '{"id": 1, "method": "debug_traceBlo
 * [Modes](/operations/avalanche/modes)
 * <a href="https://support.chainstack.com/hc/en-us/articles/900003400806-Tracing-EVM-transactions" target="_blank">Tracing EVM transactions</a>
 * <a href="https://chainstack.com/evm-nodes-a-dive-into-the-full-vs-archive-mode/" target="_blank">EVM nodes: A dive into the full vs. archive mode </a>
+* <a href="https://docs.avax.network/apis/avalanchego/apis" target="_blank">AvalancheGo API documentation</a>
+
+
 
 :::

--- a/docs/operations/avalanche/debug-and-trace-apis.md
+++ b/docs/operations/avalanche/debug-and-trace-apis.md
@@ -8,9 +8,10 @@ meta:
 
 # Debug and trace APIs
 
-You can deploy an [elastic](/glossary/elastic-node) Avalanche archive node with the enabled debug and trace APIs starting from the <a href="https://chainstack.com/pricing/" target="_blank">Business plan</a> as the Geth [client implementation](/operations/ethereum/clients).
+You can deploy an [elastic](/glossary/elastic-node) Avalanche archive node with debug and trace APIs enabled as an AvalancheGo client, which is the Go language implementation of an Avalanche node. Avalanche offers an identical API interface to [Geth's API](https://geth.ethereum.org/docs/rpc/server), but with a limited set of services that include `debug_trace*`. 
 
-For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/rpc/ns-debug).
+For a full list of the Geth debug API methods, see the [Debug namespace](https://geth.ethereum.org/docs/rpc/ns-debug) section of the Geth documentation.
+
 
 You can deploy [dedicated](/glossary/dedicated-node) Avalanche nodes starting from the <a href="https://chainstack.com/pricing/" target="_blank">Business plan</a>.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,7 +24,7 @@ meta:
 
 ### What's new
 
-* **Clouds**. You can now deploy your elastics Solana nodes using the new hosting option—[Chainstack Cloud](/glossary/chainstack-cloud) in the Netherlands region.
+* **Clouds**. You can now deploy your elastic Solana nodes using the new hosting option—[Chainstack Cloud](/glossary/chainstack-cloud) in the Netherlands region.
 
 ## Chainstack 3.5.6
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,7 +24,7 @@ meta:
 
 ### What's new
 
-* **Clouds**. You can now deploy your elastic Solana nodes using the new hosting option—[Chainstack Cloud](/glossary/chainstack-cloud) in the Netherlands region.
+* **Clouds**. You can now deploy your elastic Solana nodes using the new hosting option, [Chainstack Cloud](/glossary/chainstack-cloud), in the Netherlands region.
 
 ## Chainstack 3.5.6
 


### PR DESCRIPTION
## Description

- Added correct description of the Avalanche client used for elastic archive nodes.
- Added a missing link and modified some punctuation/typos.
- Reordered Cronos related paragraph. 