### PR TITLE
Feature/solanametal2

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-3.5.16+{BUILD_NUM}
+3.6.1+{BUILD_NUM}

--- a/docs/operations/solana/types.md
+++ b/docs/operations/solana/types.md
@@ -8,7 +8,14 @@ meta:
 
 # Types
 
-Chainstack currently supports deploying a Solana node of the [elastic type](/glossary/elastic-node).
+Chainstack currently supports deploying a Solana node of the following types: 
+*  Elastic - a highly scalable public network node infrastructure accessed through your exclusive endpoint.
+*  Dedicated - a dedicated node that is exclusive to you. This is currently only available when on [Chainstack Cloud](/glossary/chainstack-cloud). 
+
+With an elastic node, you pay for JSON-RPC requests to the node and do not pay for the compute and storage resources used by the node.
+
+With a dedicated node, you pay for the compute and storage resources used by the node and do not pay for JSON-RPC requests to the node.
+
 
 ::: tip See also
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,7 +8,15 @@ meta:
 
 # Release notes
 
-## Chainstack 3.5.8
+## Chainstack 3.6.1
+
+ *November 3, 2022*
+
+### What's new
+
+* **Protocols**. [Solana](/operations/solana/networks) elastic and dedicated full nodes now supported on both mainnet and devnet when using Chainstack Cloud in the Ashburn, USA region.
+
+## Chainstack 3.6
 
  *October 14, 2022*
 


### PR DESCRIPTION
## Description
Updated docs for Solana Bare Metal/Chainstack Cloud phase 2 - support added in Ashburn US. Feature release version is 3.6.1.

Modifed previous release version with Cronos to the 3.6 major release, by request of Maksim Solovyev.

## Related Issue
https://chainstack.myjetbrains.com/youtrack/issue/CORE-5105/Solana-bare-metal-solution-stage-2-US-ondemand
