### PR TITLE
5 Solana APIs now enabled

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-3.9.0+{BUILD_NUM}
+3.9.1+{BUILD_NUM}

--- a/docs/api/solana/getmultipleaccounts.md
+++ b/docs/api/solana/getmultipleaccounts.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
+This method is enabled for elastic Solana devnet nodes on US Ashburn (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/getmultipleaccounts.md
+++ b/docs/api/solana/getmultipleaccounts.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is currently disabled for elastic Solana devnet nodes.
+This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/getprogramaccounts.md
+++ b/docs/api/solana/getprogramaccounts.md
@@ -14,7 +14,7 @@ Solana API method that returns all accounts owned by the provided program public
 
 ::: tip Information
 
-This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
+This method is enabled for elastic Solana devnet nodes on US Ashburn (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/getprogramaccounts.md
+++ b/docs/api/solana/getprogramaccounts.md
@@ -18,7 +18,7 @@ This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1)
 
 :::
 
-On elastic Solana mainnet nodes, `getProgramAccounts` method also has a rate limit of 2 requests per second (RPS). If the rate limit is exceeded, you will get the following response:
+On elastic Solana mainnet nodes the `getProgramAccounts` method also has a rate limit of 2 requests per second (RPS). If the rate limit is exceeded, you will get the following response:
 
 ```json
 {

--- a/docs/api/solana/getprogramaccounts.md
+++ b/docs/api/solana/getprogramaccounts.md
@@ -12,9 +12,13 @@ Solana API method that returns all accounts owned by the provided program public
 
 ## Temporary limitations
 
-This method is currently disabled for elastic Solana devnet nodes.
+::: tip Information
 
-On elastic Solana mainnet nodes, `getProgramAccounts` method has a rate limit of 2 requests per second (RPS). If the rate limit is exceeded, you will get the following response:
+This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
+
+:::
+
+On elastic Solana mainnet nodes, `getProgramAccounts` method also has a rate limit of 2 requests per second (RPS). If the rate limit is exceeded, you will get the following response:
 
 ```json
 {

--- a/docs/api/solana/gettokenaccountsbydelegate.md
+++ b/docs/api/solana/gettokenaccountsbydelegate.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
+This method is enabled for elastic Solana devnet nodes on US Ashburn (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/gettokenaccountsbydelegate.md
+++ b/docs/api/solana/gettokenaccountsbydelegate.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is currently disabled for elastic Solana devnet nodes.
+This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/gettokenaccountsbyowner.md
+++ b/docs/api/solana/gettokenaccountsbyowner.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
+This method is enabled for elastic Solana devnet nodes on US Ashburn (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/gettokenaccountsbyowner.md
+++ b/docs/api/solana/gettokenaccountsbyowner.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is currently disabled for elastic Solana devnet nodes.
+This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/gettokenlargestaccounts.md
+++ b/docs/api/solana/gettokenlargestaccounts.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
+This method is enabled for elastic Solana devnet nodes on US Ashburn (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/api/solana/gettokenlargestaccounts.md
+++ b/docs/api/solana/gettokenlargestaccounts.md
@@ -10,7 +10,7 @@ meta:
 
 ::: tip Information
 
-This method is currently disabled for elastic Solana devnet nodes.
+This method is now enabled for elastic Solana devnet nodes on US Ashborne (ash1) and Amsterdam (ams1) with a rate limit of 2 requests per second (RPS).
 
 :::
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,13 @@ meta:
 
 # Release notes
 
+## Chainstack 3.9.X
+
+*January 17, 2023*
+
+* **APIs**. 5 Heavy [Solana APIs](/api/solana/solana-api-reference) enabled.
+* **Documentation**. Solana API [reference](/api/solana/solana-api-reference) updates.
+
 ## Chainstack 3.9
 
 *January 10, 2023*
@@ -76,8 +83,9 @@ meta:
 *November 7, 2022*
 
 ### What's new
-- **Protocols**. [Aurora](/operations/aurora/types) support for dedicated nodes.
-- **Documentation**. A simple on-chain governance tutorial for [Aurora](/tutorials/aurora).
+
+* **Protocols**. [Aurora](/operations/aurora/types) support for dedicated nodes.
+* **Documentation**. A simple on-chain governance tutorial for [Aurora](/tutorials/aurora).
 
 ## Chainstack 3.6.1
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,11 +8,11 @@ meta:
 
 # Release notes
 
-## Chainstack 3.9.X
+## Chainstack 3.9.1
 
 *January 17, 2023*
 
-* **APIs**. 5 Heavy [Solana APIs](/api/solana/solana-api-reference) enabled.
+* **APIs**. 5 [Solana APIs](/api/solana/solana-api-reference) enabled on devnet.
 * **Documentation**. Solana API [reference](/api/solana/solana-api-reference) updates.
 
 ## Chainstack 3.9


### PR DESCRIPTION
## Description
5 heavy Solana APIs were enabled in ash1 and ams1 rate limited at 2RPS. Already implemented by dev so Nare requested doc updates asap. 

Only 5 APIs pages needed to have the Information note at the top updated.

Content reviewed and approved by PM Vladimir Feofilaktov in Slack. 

## Related Issue

https://chainstack.myjetbrains.com/youtrack/issue/DOCS-36/FVM-testnet-user-documentation

