### PR TITLE
Remove Ropsten and Rinkeby testnets from docs

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-3.9.9+{BUILD_NUM}
+3.10.0+{BUILD_NUM}

--- a/docs/api/ethereum/eth_sendrawtransaction.md
+++ b/docs/api/ethereum/eth_sendrawtransaction.md
@@ -59,7 +59,7 @@ web3.eth.getTransactionCount(sender, (err, transactionCount) => {
 
     // create a new transaction object to sign
     const tx = new Tx(transaction_Object, {
-        chain: "ropsten"
+        chain: "mainnet"
     });
 
     // sign the transaction using the private key  

--- a/docs/blockchains/ethereum.md
+++ b/docs/blockchains/ethereum.md
@@ -3,7 +3,7 @@ meta:
   - name: description
     content: Ethereum is a public permissionless blockchain protocol. Learn how to join the Ethereum mainnet or testnets and operate an Ethereum node.
   - name: keywords
-    content: ethereum blockchain ropsten goerli eth2 nimbus mainnet node
+    content: ethereum blockchain sepolia goerli eth2 nimbus mainnet node
 ---
 
 # Ethereum
@@ -13,10 +13,8 @@ Ethereum is a public permissionless blockchain protocol.
 Chainstack currently supports joining the following Ethereum networks:
 
 * Mainnet — public Ethereum mainnet.
-* Goerli testnet — a proof-of-stake public Ethereum testnet.
 * Sepolia testnet — a proof-of-stake public permissioned Ethereum testnet.
-* Ropsten testnet — a proof-of-work public Ethereum testnet.
-* Rinkeby testnet — a proof-of-authority public Ethereum testnet.
+* Goerli testnet — a proof-of-stake public Ethereum testnet.
 
 For development purposes on Ethereum testnets, fund your accounts with <a href="https://support.chainstack.com/hc/en-us/articles/900001458966-Ethereum-testnet-faucets" target="_blank">testnet ether</a>.
 

--- a/docs/operations/ethereum/networks.md
+++ b/docs/operations/ethereum/networks.md
@@ -1,9 +1,9 @@
 ---
 meta:
   - name: description
-    content: Deploy a public Ethereum node on mainnet, Goerli, Ropsten, or Rinkeby with Chainstack in seconds.
+    content: Deploy a public Ethereum node on mainnet, Sepolia, or Goerli  with Chainstack in seconds.
   - name: keywords
-    content: ethereum mainnet ropsten rinkeby goerli testnet node eth2
+    content: ethereum mainnet sepolia goerli testnet node eth2
 ---
 
 # Networks
@@ -11,10 +11,8 @@ meta:
 Chainstack supports joining the following Ethereum networks:
 
 * Mainnet — public Ethereum mainnet.
-* Goerli testnet — a proof-of-stake public Ethereum testnet.
 * Sepolia testnet — a proof-of-stake public permissioned Ethereum testnet.
-* Ropsten testnet — a proof-of-stake public Ethereum testnet.
-* Rinkeby testnet — a proof-of-authority public Ethereum testnet.
+* Goerli testnet — a proof-of-stake public Ethereum testnet.
 
 For development purposes on Ethereum testnets, fund your accounts with <a href="https://support.chainstack.com/hc/en-us/articles/900001458966-Ethereum-testnet-faucets" target="_blank">testnet ether</a>.
 

--- a/docs/operations/ethereum/tools.md
+++ b/docs/operations/ethereum/tools.md
@@ -776,10 +776,8 @@ where
 * PASSWORD — your node access password.
 * NETWORK_ID — Ethereum network ID:
    * Mainnet: `1`
-   * Goerli: `5`
    * Sepolia: `11155111`
-   * Ropsten: `3`
-   * Rinkeby: `4`
+   * Goerli: `5`
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -833,10 +831,8 @@ where
 * ENDPOINT — your node WSS endpoint.
 * NETWORK_ID — Ethereum network ID:
   * Mainnet: `1`
-  * Goerli: `5`
   * Sepolia: `11155111`
-  * Ropsten: `3`
-  * Rinkeby: `4`
+  * Goerli: `5`
 
 See also [View node access and credentials](/platform/view-node-access-and-credentials).
 
@@ -883,10 +879,8 @@ where
 * ENDPOINT — your node HTTPS or WSS endpoint.
 * NETWORK_ID — Ethereum network ID:
    * Mainnet: `1`
-   * Goerli: `5`
    * Sepolia: `11155111`
-   * Ropsten: `3`
-   * Rinkeby: `4`
+   * Goerli: `5`
 
 Example to add an Ethereum mainnet node to the list of Brownie networks:
 

--- a/docs/platform/join-a-public-network.md
+++ b/docs/platform/join-a-public-network.md
@@ -12,7 +12,7 @@ meta:
 
 1. Select a [public chain project](/glossary/public-chain-project) and click **Get started** or **Join network**.
 1. Under **Blockchain protocol**, select **Ethereum**.
-1. Under **Blockchain network**, select **Mainnet**, **Goerli testnet**, **Sepolia testnet**, **Ropsten testnet**, or **Rinkeby testnet**. Click **Next**.
+1. Under **Blockchain network**, select **Mainnet**, **Sepolia testnet**, or **Goerli testnet**. Click **Next**.
 1. Under **Type**, select whether to run an [elastic](/glossary/elastic-node) or a [dedicated](/glossary/dedicated-node) node.
 1. Under **Mode**, select whether to run a full node or an archive node. See [Modes](/operations/ethereum/modes).
 1. If you are deploying a dedicated archive node, under **Client**, select whether to run a Geth node or an Erigon node. See [Clients](/operations/ethereum/clients).

--- a/docs/platform/supported-protocols.md
+++ b/docs/platform/supported-protocols.md
@@ -12,10 +12,8 @@ Public network:
 
 * [Ethereum](/blockchains/ethereum)
 	* Mainnet. [Full and archive nodes](/operations/ethereum/modes).
-	* Goerli testnet
 	* Sepolia testnet
-	* Ropsten testnet
-	* Rinkeby testnet
+	* Goerli testnet
 * [Polygon PoS](/blockchains/polygon)
 	* Mainnet. [Full and archive nodes](/operations/polygon/modes).
 	* Mumbai testnet

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,14 @@ meta:
 
 # Release notes
 
+## Chainstack 3.11.6
+
+*March 6, 2023*
+
+### What's new
+
+* **Protocols**. Ethereum Rinkeby and Ropsten testnets are now deprecated. For development purposes, use [Sepolia and Goerli](/operations/ethereum/networks) testnets.
+
 ## Chainstack 3.11.5
 
 *February 22, 2023*


### PR DESCRIPTION
## Description
remove Ropsten and Rinkeby from docs
add relnotes
change version

## Issues
[DOCS-70: Remove Ropsten and Rinkeby Ethereum testnets from docs](https://chainstack.myjetbrains.com/youtrack/issue/DOCS-70) 